### PR TITLE
Add Selective reporting view

### DIFF
--- a/src/senaite/ast/adapters/listing.py
+++ b/src/senaite/ast/adapters/listing.py
@@ -41,6 +41,9 @@ class ASTPanelViewAdapter(object):
         self.context = context
 
     def before_render(self):
+        # If there are microorganisms identified for the current sample,
+        # display a new filter "Identified microorganisms" and make it the
+        # default, so only identified microorganisms are listed
         microorganisms = utils.get_identified_microorganisms(self.context)
         if microorganisms:
             # Get the microorganisms uids

--- a/src/senaite/ast/browser/configure.zcml
+++ b/src/senaite/ast/browser/configure.zcml
@@ -48,7 +48,15 @@
     permission="senaite.core.permissions.ManageAnalysisRequests"
     layer="senaite.ast.interfaces.ISenaiteASTLayer" />
 
-  <!-- Adds a Panel to the Sample -->
+  <!-- AST Panel selective reporting view -->
+  <browser:page
+    for="bika.lims.interfaces.IAnalysisRequest"
+    name="ast_reporting"
+    class=".reporting.ASTPanelReportingView"
+    permission="senaite.core.permissions.ManageAnalysisRequests"
+    layer="senaite.ast.interfaces.ISenaiteASTLayer" />
+
+  <!-- End-point for the addition of a Panel to the Sample -->
   <browser:page
     for="bika.lims.interfaces.IAnalysisRequest"
     name="add_ast_panel"

--- a/src/senaite/ast/browser/panel.py
+++ b/src/senaite/ast/browser/panel.py
@@ -21,8 +21,6 @@
 import collections
 
 from bika.lims import api
-from bika.lims import senaiteMessageFactory as _sc
-from bika.lims.catalog import CATALOG_ANALYSIS_LISTING
 from bika.lims.catalog import SETUP_CATALOG
 from bika.lims.interfaces import ISubmitted
 from bika.lims.interfaces import IVerified
@@ -32,12 +30,17 @@ from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from senaite.app.listing.view import ListingView
 from senaite.ast import messageFactory as _
 from senaite.ast import utils
+from senaite.ast.config import REPORT_KEY
 from senaite.ast.config import RESISTANCE_KEY
 from senaite.ast.config import ZONE_SIZE_KEY
-from senaite.ast.config import REPORT_KEY
 
 
 class ASTPanelView(ListingView):
+    """Listing view that represents the configuration of an AST Panel,
+    displaying microorganisms as rows and antibiotics as rows. A checkbox is
+    rendered on each cell, meaning that an AST result will be expected for
+    that microorganism-antibiotic tuple
+    """
 
     template = ViewPageTemplateFile("templates/ast_panel.pt")
 
@@ -71,7 +74,7 @@ class ASTPanelView(ListingView):
         self.review_states = [
             {
                 "id": "default",
-                "title": _sc("All microorganisms"),
+                "title": _("All microorganisms"),
                 "contentFilter": {},
                 "columns": self.columns.keys(),
             }
@@ -203,7 +206,7 @@ class ASTPanelView(ListingView):
         """Returns the ast-analyses for this microorganism, antibiotic and
         current context, if any
         """
-        ans = self.get_analyses()
+        ans = self.get_analyses(skip_invalid=skip_invalid)
 
         # Microorganism name is the ShortTitle
         if microorganism:
@@ -213,10 +216,6 @@ class ASTPanelView(ListingView):
         # Antibiotic is defined as an interim
         if antibiotic:
             ans = filter(lambda a: self.has_antibiotic(a, antibiotic), ans)
-
-        # Skip invalids
-        skip = skip_invalid and ["cancelled", "retracted", "rejected"] or []
-        ans = filter(lambda a: api.get_review_status(a) not in skip, ans)
 
         return ans
 
@@ -243,16 +242,10 @@ class ASTPanelView(ListingView):
         return antibiotic[0]
 
     @view.memoize
-    def get_analyses(self):
+    def get_analyses(self, skip_invalid=False):
         """Returns the list of ast-like analyses from current context
         """
-        query = {
-            "portal_type": "Analysis",
-            "getPointOfCapture": "ast",
-            "getAncestorsUIDs": [api.get_uid(self.context)],
-        }
-        brains = api.search(query, CATALOG_ANALYSIS_LISTING)
-        return map(api.get_object, brains)
+        return utils.get_ast_analyses(self.context, skip_invalid=skip_invalid)
 
     @view.memoize
     def get_antibiotics(self):

--- a/src/senaite/ast/browser/reporting.py
+++ b/src/senaite/ast/browser/reporting.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.AST.
+#
+# SENAITE.AST is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free
+# Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2020 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from bika.lims import api
+from plone.memoize import view
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from senaite.ast import messageFactory as _
+from senaite.ast import utils
+from senaite.ast.browser.panel import ASTPanelView
+from senaite.ast.config import REPORT_KEY
+
+
+class ASTPanelReportingView(ASTPanelView):
+    """Listing view for selective reporting of AST results. Displays a listing
+    where rows are microorganisms and columns antibiotics. A checkbox is
+    rendered on each cell, meaning that an AST result for the selected tuple
+    microorganism-antibiotic will be reported in results report when checked
+    """
+
+    template = ViewPageTemplateFile("templates/ast_reporting.pt")
+
+    def __init__(self, context, request):
+        super(ASTPanelReportingView, self).__init__(context, request)
+        self.title = _("AST Panel Selective Reporting")
+        self.show_search = False
+
+    def before_render(self):
+        pass
+
+    def update(self):
+        super(ASTPanelReportingView, self).update()
+
+        # Keep the microorganisms assigned to the Sample's AST panel only
+        uids = map(api.get_uid, self.get_microorganisms())
+        self.contentFilter.update({
+            "UID": uids,
+        })
+
+    def render_checkbox(self, item, microorganism, antibiotic):
+        """Renders the checkbox properties for the item, microorganism and
+        antibiotic passed-in
+        """
+        uid = api.get_uid(antibiotic)
+        has_analysis = self.has_analysis_for(microorganism, antibiotic)
+
+        if self.can_add_analyses():
+            # The sample is in an editable status
+            item["allow_edit"].append(uid)
+
+        item[uid] = has_analysis
+        if has_analysis and self.is_editable(microorganism, antibiotic):
+            return
+
+        # There is no analysis or is not editable. Disable the checkbox
+        item.setdefault("disabled", []).append(uid)
+
+    @view.memoize
+    def get_microorganisms(self):
+        """Returns the list of microorganism objects assigned to this sample,
+        sorted by title ascending
+        """
+        analyses = self.get_analyses(skip_invalid=True)
+        microorganisms = utils.get_microorganisms(analyses)
+        return sorted(microorganisms, key=lambda m: api.get_title(m))
+
+    @view.memoize
+    def get_antibiotics(self):
+        """Returns the list of antibiotics objects assigned to this sample,
+        sorted by title ascending
+        """
+        analyses = self.get_analyses(skip_invalid=True)
+        antibiotics = utils.get_antibiotics(analyses)
+        return sorted(antibiotics, key=lambda ab: api.get_title(ab))
+
+    def update_analyses(self, microorganism, antibiotics):
+        """Update the ast reporting analyses for the given microorganism and
+        list of antibiotics
+        """
+        # Get the selective reporting analysis for the given microorganism
+        analyses = self.get_analyses_for(microorganism, skip_invalid=True)
+        analyses = filter(lambda a: a.getKeyword() == REPORT_KEY, analyses)
+        if not analyses:
+            return
+
+        # Reporting is true for the given antibiotics
+        selected = map(lambda o: o.abbreviation, antibiotics)
+        for analysis in analyses:
+            interim_fields = analysis.getInterimFields()
+            for antibiotic in interim_fields:
+                keyword = antibiotic.get("keyword")
+                # choices = "0:|1:Y|2:N"
+                value = "1" if keyword in selected else "2"
+                antibiotic.update({
+                    "value": value
+                })

--- a/src/senaite/ast/browser/results.py
+++ b/src/senaite/ast/browser/results.py
@@ -153,11 +153,8 @@ class ManageResultsView(AnalysesView):
                 if field not in item:
                     item[field] = ""
 
-        # XXX order the list of interim columns
-        interim_keys = self.interim_columns.keys()
-        interim_keys.reverse()
-
         # Add InterimFields keys (Antibiotic abbreviations) to columns
+        interim_keys = sorted(self.interim_columns.keys(), reverse=True)
         for col_id in interim_keys:
             if col_id not in self.columns:
                 self.columns[col_id] = {

--- a/src/senaite/ast/browser/templates/ast_reporting.pt
+++ b/src/senaite/ast/browser/templates/ast_reporting.pt
@@ -19,13 +19,13 @@
     <metal:core fill-slot="content-core">
 
       <form class="form"
-            name="ast_panel"
-            action="ast_panel"
+            name="ast_reporting"
+            action="ast_reporting"
             method="POST">
 
         <div tal:content="structure view/contents_table"></div>
 
-        <div tal:condition="python: view.can_add_analyses()">
+        <div>
             <!-- Hidden Fields -->
             <input type="hidden" name="submitted" value="1"/>
             <input tal:replace="structure context/@@authenticator/authenticator"/>

--- a/src/senaite/ast/browser/templates/ast_results.pt
+++ b/src/senaite/ast/browser/templates/ast_results.pt
@@ -36,9 +36,14 @@
                   i18n:translate="">Add</button>
 
           <a id="astpanel_custom"
-             class="btn btn-outline-primary btn-sm"
+             class="btn btn-outline-primary btn-sm mr-2"
              tal:attributes="href python:context.absolute_url() + '/ast_panel'"
              i18n:translate="">Custom ...</a>
+
+          <a class="btn btn-outline-secondary btn-sm mr-2"
+             tal:attributes="href python:context.absolute_url() + '/ast_reporting'"
+             i18n:translate="">Selective reporting</a>
+
         </div>
       </form>
     </div>

--- a/src/senaite/ast/utils.py
+++ b/src/senaite/ast/utils.py
@@ -273,7 +273,7 @@ def get_ast_siblings(analysis):
 def get_identified_microorganisms(sample):
     """Returns the identified microorganisms from the sample passed-in. It
     resolves the microorganisms by looking to the results of the
-    "Identification" analyses
+    "Identification" analysis
     """
     keyword = IDENTIFICATION_KEY
     ans = sample.getAnalyses(getKeyword=keyword, full_objects=True)
@@ -289,6 +289,43 @@ def get_identified_microorganisms(sample):
     # Get the microorganisms
     objects = api.get_setup().microorganisms.objectValues()
     return filter(lambda m: api.get_title(m) in names, objects)
+
+
+def get_microorganism(analysis):
+    """Returns the microorganism object from the analysis passed-in, if any
+    """
+    microorganism = get_microorganisms([analysis, ])
+    return microorganism and microorganism[0] or None
+
+
+def get_microorganisms(analyses):
+    """Returns the list of microorganisms from the analyses passed-in
+    """
+    names = map(lambda a: a.getShortTitle(), analyses)
+    objects = api.get_setup().microorganisms.objectValues()
+    objects = filter(lambda m: api.get_title(m) in names, objects)
+    return filter(None, objects)
+
+
+def get_antibiotics(analyses):
+    """Returns the list of antibiotics assigned to the analyses passed-in
+    """
+    if isinstance(analyses, (list, tuple)):
+        abx = map(get_antibiotics, analyses)
+        abx = list(itertools.chain.from_iterable(abx))
+        # Remove duplicates and Nones
+        return filter(None, list(set(abx)))
+
+    # Antibiotics are stored as interim fields and keyword is the abbreviation
+    analysis = api.get_object(analyses)
+    interim_fields = analysis.getInterimFields()
+    abbreviations = map(lambda i: i.get("keyword"), interim_fields)
+    abbreviations = filter(None, abbreviations)
+
+    # Get the antibiotics
+    objects = api.get_setup().antibiotics.objectValues()
+    objects = filter(lambda a: a.abbreviation in abbreviations, objects)
+    return filter(None, objects)
 
 
 def get_microorganisms_from_result(analysis):


### PR DESCRIPTION
This pull request adds a new button "Selective reporting" next to "Customize" [AST Panel] that redirects the user to easily choose the resistance results to be rendered in results report.

![Captura de 2020-12-20 12-27-29](https://user-images.githubusercontent.com/832627/102712111-c0280600-42be-11eb-8944-494ddabf4861.png)


![Captura de 2020-12-20 12-24-31](https://user-images.githubusercontent.com/832627/102712091-966edf00-42be-11eb-96c2-ba2200eeeadc.png)
