### PR TITLE
Allow user to choose microorganism groups in breakpoints tables

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,8 +1,8 @@
 [buildout]
 index = https://pypi.org/simple/
-extends = https://dist.plone.org/release/5.2.4/versions.cfg
+extends = https://dist.plone.org/release/5.2.6/versions.cfg
 find-links =
-    https://dist.plone.org/release/5.2.4/
+    https://dist.plone.org/release/5.2.6/
     https://dist.plone.org/thirdparty/
 
 parts =

--- a/src/senaite/ast/behaviors/breakpointstable.py
+++ b/src/senaite/ast/behaviors/breakpointstable.py
@@ -42,8 +42,8 @@ class IBreakpointsTableSchema(Interface):
     )
 
     microorganism = schema.Choice(
-        title=_("Microorganism"),
-        source="senaite.ast.vocabularies.microorganisms",
+        title=_(u"Species"),
+        source="senaite.ast.vocabularies.species",
         required=True,
     )
 

--- a/src/senaite/ast/browser/panel.py
+++ b/src/senaite/ast/browser/panel.py
@@ -30,9 +30,11 @@ from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from senaite.app.listing.view import ListingView
 from senaite.ast import messageFactory as _
 from senaite.ast import utils
+from senaite.ast.config import BREAKPOINTS_TABLE_KEY
 from senaite.ast.config import REPORT_KEY
 from senaite.ast.config import RESISTANCE_KEY
 from senaite.ast.config import ZONE_SIZE_KEY
+from senaite.ast.utils import get_breakpoints_tables_for
 
 
 class ASTPanelView(ListingView):
@@ -129,8 +131,8 @@ class ASTPanelView(ListingView):
         if not analyses:
             if antibiotics:
                 # Create new analyses
-                keywords = [ZONE_SIZE_KEY, RESISTANCE_KEY]
-                utils.create_ast_analyses(self.context, keywords, microorganism,
+                keys = [BREAKPOINTS_TABLE_KEY, ZONE_SIZE_KEY, RESISTANCE_KEY]
+                utils.create_ast_analyses(self.context, keys, microorganism,
                                           antibiotics)
 
         elif not antibiotics:

--- a/src/senaite/ast/configure.zcml
+++ b/src/senaite/ast/configure.zcml
@@ -27,6 +27,9 @@
   <utility
       component="senaite.ast.vocabularies.MicroorganismsVocabularyFactory"
       name="senaite.ast.vocabularies.microorganisms" />
+  <utility
+      component="senaite.ast.vocabularies.SpeciesVocabularyFactory"
+      name="senaite.ast.vocabularies.species" />
 
   <!-- Datamanagers -->
   <adapter factory=".datamanagers.ASTAnalysisDataManager" />

--- a/src/senaite/ast/tests/doctests/AST.rst
+++ b/src/senaite/ast/tests/doctests/AST.rst
@@ -1,0 +1,59 @@
+Anitbiotic Sensitivity Testing
+------------------------------
+
+Running this test from the buildout directory:
+
+    bin/test test_textual_doctests -t AST
+
+
+Test Setup
+..........
+
+Needed Imports:
+
+    >>> from DateTime import DateTime
+    >>> from bika.lims import api
+    >>> from bika.lims.utils.analysisrequest import create_analysisrequest
+    >>> from plone.app.testing import TEST_USER_ID
+    >>> from plone.app.testing import TEST_USER_PASSWORD
+    >>> from plone.app.testing import setRoles
+
+Variables:
+
+    >>> portal = self.portal
+    >>> request = self.request
+    >>> setup = api.get_setup()
+    >>> date_now = DateTime().strftime("%Y-%m-%d")
+
+Functional Helpers:
+
+    >>> def new_sample(services, client, contact, sampletype):
+    ...     values = {
+    ...         'Client': client.UID(),
+    ...         'Contact': contact.UID(),
+    ...         'DateSampled': date_now,
+    ...         'SampleType': sampletype.UID()}
+    ...     service_uids = map(api.get_uid, services)
+    ...     sample = create_analysisrequest(client, request, values, service_uids)
+    ...     return sample
+
+We need to create some basic objects for the test:
+
+    >>> setRoles(portal, TEST_USER_ID, ['LabManager',])
+    >>> client = api.create(portal.clients, "Client", Name="Happy Hills", ClientID="HH", MemberDiscountApplies=True)
+    >>> contact = api.create(client, "Contact", Firstname="Rita", Lastname="Mohale")
+    >>> sampletype = api.create(setup.bika_sampletypes, "SampleType", title="Blood", Prefix="B")
+    >>> labcontact = api.create(setup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
+    >>> department = api.create(setup.bika_departments, "Department", title="Microbiology", Manager=labcontact)
+    >>> category = api.create(setup.bika_analysiscategories, "AnalysisCategory", title="Microbiology", Department=department)
+    >>> g = api.create(setup.bika_analysisservices, "AnalysisService", title="GRAM Test", Keyword="G", Price="15", Category=category.UID(), Accredited=True)
+
+
+Sample setup
+............
+
+Create a new sample:
+
+    >>> sample = new_sample([g], client, contact, sampletype)
+    >>> api.get_workflow_status_of(sample)
+    'sample_due'

--- a/src/senaite/ast/tests/layers.py
+++ b/src/senaite/ast/tests/layers.py
@@ -15,6 +15,11 @@ class BaseLayer(PloneSandboxLayer):
         # Load ZCML
         import bika.lims
         import senaite.app.listing
+        import senaite.app.spotlight
+        import senaite.core
+        import senaite.abx
+        import senaite.ast
+        import senaite.impress
         import senaite.microorganism
 
         self.loadZCML(package=bika.lims)
@@ -25,10 +30,9 @@ class BaseLayer(PloneSandboxLayer):
         self.loadZCML(package=senaite.lims)
         self.loadZCML(package=senaite.abx)
         self.loadZCML(package=senaite.microorganism)
-        self.loadZCML(pakcage=senaite.ast)
+        self.loadZCML(package=senaite.ast)
 
         # Install product and call its initialize() function
-        zope.installProduct(app, "Products.TextIndexNG3")
         zope.installProduct(app, "bika.lims")
         zope.installProduct(app, "senaite.core")
         zope.installProduct(app, "senaite.app.listing")
@@ -42,7 +46,7 @@ class BaseLayer(PloneSandboxLayer):
     def setUpPloneSite(self, portal):
         # Install into Plone site using portal_setup
         applyProfile(portal, "senaite.core:default")
-        applyProfile(portal, "senaite.databox:default")
+        applyProfile(portal, "senaite.ast:default")
         transaction.commit()
 
 


### PR DESCRIPTION
This Pull Request takes advantage of https://github.com/senaite/senaite.microorganism/pull/4 to allow the user to specify both microorganism groups/categories and/or specific microorganisms for breakpoints in AST Breakpoints Table edit view. 

If there is a breakpoint defined for a given microorganism and antibiotic twice (an entry for both the category and the microorganism is defined), the system gives priority to the breakpoint that refers to the specific microorganism instead of the group.

![Captura de 2021-11-18 12-57-50](https://user-images.githubusercontent.com/832627/142411878-7e27fa26-b72e-4670-bef7-dbb3208e093e.png)
