### PR TITLE
Prevent samples transition to to_be_verified or verified

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,7 @@
+## Steps to reproduce
+
+## Current behavior
+
+## Expected behavior
+
+## Screenshot (optional)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## Description of the issue/feature this PR addresses
+
+Linked issue: https://github.com/senaite/senaite.ast/issues/
+
+## Current behavior before PR
+
+## Desired behavior after PR is merged
+
+--
+I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
+and [Plone's Python styleguide][2] standards.
+
+[1]: https://www.python.org/dev/peps/pep-0008
+[2]: https://docs.plone.org/develop/styleguide/python.html

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -42,15 +42,15 @@ sources = sources
 auto-checkout = *
 
 [sources]
-senaite.core = git git://github.com/senaite/senaite.core.git pushurl=git@github.com:senaite/senaite.core.git branch=2.x
-senaite.app.listing = git git://github.com/senaite/senaite.app.listing.git pushurl=git@github.com:senaite/senaite.app.listing.git branch=2.x
-senaite.app.spotlight = git git://github.com/senaite/senaite.app.spotlight.git pushurl=git@github.com:senaite/senaite.app.spotlight.git branch=2.x
-senaite.app.supermodel = git git://github.com/senaite/senaite.app.supermodel.git pushurl=git@github.com:senaite/senaite.app.supermodel.git branch=2.x
-senaite.impress = git git://github.com/senaite/senaite.impress.git pushurl=git@github.com:senaite/senaite.impress.git branch=2.x
-senaite.jsonapi = git git://github.com/senaite/senaite.jsonapi.git pushurl=git@github.com:senaite/senaite.jsonapi.git branch=2.x
-senaite.lims = git git://github.com/senaite/senaite.lims.git pushurl=git@github.com:senaite/senaite.lims.git branch=2.x
-senaite.abx = git git://github.com/senaite/senaite.abx.git pushurl=git@github.com:senaite/senaite.abx.git
-senaite.microorganism = git git://github.com/senaite/senaite.microorganism.git pushurl=git@github.com:senaite/senaite.microorganism.git
+senaite.core = git https://github.com/senaite/senaite.core.git branch=2.x
+senaite.app.listing = git https://github.com/senaite/senaite.app.listing.git branch=2.x
+senaite.app.spotlight = git https://github.com/senaite/senaite.app.spotlight.git branch=2.x
+senaite.app.supermodel = git https://github.com/senaite/senaite.app.supermodel.git branch=2.x
+senaite.impress = git https://github.com/senaite/senaite.impress.git branch=2.x
+senaite.jsonapi = git https://github.com/senaite/senaite.jsonapi.git branch=2.x
+senaite.lims = git https://github.com/senaite/senaite.lims.git branch=2.x
+senaite.abx = git https://github.com/senaite/senaite.abx.git
+senaite.microorganism = git https://github.com/senaite/senaite.microorganism.git
 
 [instance]
 recipe = plone.recipe.zope2instance

--- a/src/senaite/ast/adapters/configure.zcml
+++ b/src/senaite/ast/adapters/configure.zcml
@@ -10,4 +10,11 @@
     provides="senaite.app.listing.interfaces.IListingViewAdapter"
     factory=".listing.ASTPanelViewAdapter" />
 
+  <!-- Guard handler for AnalysisRequest (aka Sample) content type -->
+  <adapter
+      for="bika.lims.interfaces.IAnalysisRequest"
+      provides="bika.lims.interfaces.IGuardAdapter"
+      factory=".guards.SampleGuardAdapter"
+      name="senaite.ast.adapter.guard.sample" />
+
 </configure>

--- a/src/senaite/ast/adapters/guards.py
+++ b/src/senaite/ast/adapters/guards.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.AST.
+#
+# SENAITE.AST is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free
+# Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2020-2021 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from bika.lims.interfaces import IGuardAdapter
+from bika.lims.interfaces import ISubmitted
+from bika.lims.interfaces import IVerified
+from senaite.ast import utils
+from zope.interface import implementer
+
+
+class BaseGuardAdapter(object):
+
+    def __init__(self, context):
+        self.context = context
+
+    def guard(self, action):
+        func_name = "guard_{}".format(action)
+        func = getattr(self, func_name, None)
+        if func:
+            return func()
+
+        # No guard intercept here
+        return True
+
+
+@implementer(IGuardAdapter)
+class SampleGuardAdapter(BaseGuardAdapter):
+    """AST-like analyses are set as 'Internal', but 'submit' and 'verify' guards
+    from senaite.core dismiss internal analyses.
+    "Final" analyses with AST category for each Microorganism and antibiotic
+    are automatically created once the intermediate AST analyses are submitted
+    (diameter zone, content, etc.).
+    """
+
+    def guard_submit(self):
+        """Returns true when results for valid AST analyses have been submitted
+        """
+        # Get the valid AST-like analyses
+        analyses = utils.get_ast_analyses(self.context)
+        submitted = map(ISubmitted.providedBy, analyses)
+        if all(submitted):
+            # All AST-like analyses have been submitted
+            return True
+
+        return False
+
+    def guard_verify(self):
+        """Returns true if all valid AST analyses have been verified.
+        """
+        analyses = utils.get_ast_analyses(self.context)
+        verified = map(IVerified.providedBy, analyses)
+        if all(verified):
+            # All AST-like analyses have been verified
+            return True
+
+        return False


### PR DESCRIPTION
# Description of the issue/feature this PR addresses

This Pull Request prevents samples to automatically transition to `to_be_verified` or `verified` statuses when the sample has AST-like analyses with result still pending or not submitted.

## Current behavior before PR

Sample transitions skip AST-like analyses status because they are flagged as "internal"

## Desired behavior after PR is merged

AST-like analyses are considered for Sample transitions "submit" and "verify"

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html