### PR TITLE
Keep same order as the AST Panel in results entry

### DIFF
--- a/src/senaite/ast/browser/results.py
+++ b/src/senaite/ast/browser/results.py
@@ -163,7 +163,8 @@ class ManageResultsView(AnalysesView):
                     item[field] = ""
 
         # Add InterimFields keys (Antibiotic abbreviations) to columns
-        interim_keys = sorted(self.interim_columns.keys(), reverse=True)
+        interim_keys = self.interim_columns.keys()
+        interim_keys.reverse()
         for col_id in interim_keys:
             if col_id not in self.columns:
                 self.columns[col_id] = {


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes the columns (antibiotics) of the AST results entry to be displayed in same order as they are defined in the AST Panel of choice.

## Current behavior before PR

The columns with the antibiotic abbreviations are sorted alphabetically

![image1](https://user-images.githubusercontent.com/832627/148208534-e816bc5b-5ef0-429f-b9fe-2f78847b49e4.png)

## Desired behavior after PR is merged

The columns with the antibiotic abbreviations are sorted in accordance with the configuration set in the AST Panel edit view:

![image2](https://user-images.githubusercontent.com/832627/148208562-a6a70038-55a7-4d78-a1c8-212053ff6943.png)

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
