### PR TITLE
Allow to remove retracted AST analyses retests

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,4 +4,5 @@ Changelog
 1.0.0 (unreleased)
 ------------------
 
+- #10 Allow to remove retracted AST analyses retests
 - Initial Release

--- a/src/senaite/ast/browser/panel.py
+++ b/src/senaite/ast/browser/panel.py
@@ -201,7 +201,7 @@ class ASTPanelView(ListingView):
         antibiotic and current context
         """
         analyses = self.get_analyses_for(microorganism, antibiotic,
-                                         skip_invalid=False)
+                                         skip_invalid=True)
         analyses = filter(ISubmitted.providedBy, analyses)
         return len(analyses) == 0
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR allows to remove previously retracted AST analyses with the AST panel view

## Current behavior before PR

Previously retracted AST analyses retests are rendered as readonly, so that the checkboxes to deselect were disabled

## Desired behavior after PR is merged

Retracted AST analyses retests are rendered as editable, so that the checkboxes can be deselected to remove the analysis

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
