### PR TITLE
Better styling of AST Panel selector in Sample view

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,5 +4,6 @@ Changelog
 1.0.0 (unreleased)
 ------------------
 
+- #11 Better styling of AST Panel selector in Sample view
 - #10 Allow to remove retracted AST analyses retests
 - Initial Release

--- a/src/senaite/ast/browser/templates/ast_results.pt
+++ b/src/senaite/ast/browser/templates/ast_results.pt
@@ -3,50 +3,53 @@
   i18n:domain="senaite.ast">
 
   <!-- Form for the assignment of an AST panel -->
-  <div class="row mt-3 mb-3"
-       tal:condition="python: view.can_add_analyses()">
-    <div class="col-sm-12">
-      <form id="add_ast_panel_form"
-            class="form form-inline"
-            method="post"
-            tal:attributes="action here/absolute_url">
+  <div class="row col-sm-12" tal:condition="python: view.can_add_analyses()">
+    <form id="add_ast_panel_form"
+          class="form"
+          method="post"
+          tal:attributes="action here/absolute_url">
 
-        <input type="hidden" name="submitted" value="1"/>
-        <input tal:replace="structure context/@@authenticator/authenticator"/>
+      <input type="hidden" name="submitted" value="1"/>
+      <input tal:replace="structure context/@@authenticator/authenticator"/>
 
-        <!-- ASP Panels selector -->
-        <div class="form-group">
+      <!-- ASP Panels selector -->
+      <div class="input-group input-group-sm flex-nowrap d-inline-flex w-auto mb-3 astpanel-selector">
+        <div class="input-group-prepend">
           <label for="ast_panel_selector"
-                 class="field mr-2"
-                 i18n:translate="">Panels</label>
+                 class="input-group-text"
+                 i18n:translate="">Panel</label>
+        </div>
 
-          <select id="ast_panel_selector"
-                  name="ast_panel_selector"
-                  class="field form-control mr-2">
-                  <option value="" i18n:translate="">Select panel</option>
-                  <option tal:repeat="panel python:view.get_panels()"
-                          tal:attributes="value panel/uid"
-                          tal:content="panel/title" />
-          </select>
+        <select id="ast_panel_selector"
+                name="ast_panel_selector"
+                class="custom-select">
+          <option value="" i18n:translate="">Select panel</option>
+          <option tal:repeat="panel python:view.get_panels()"
+                  tal:attributes="value panel/uid"
+                  tal:content="panel/title" />
+        </select>
 
+        <!-- AST Panel add button -->
+        <div class="input-group-append">
           <button id="astpanel_add"
                   name="astpanel_add"
                   type="submit"
-                  class="btn btn-outline-primary btn-sm mr-2"
-                  i18n:translate="">Add</button>
-
+                  class="btn btn-outline-primary btn-sm"
+                  i18n:translate="">Add panel</button>
+        </div>
+        <div class="input-group-append">
           <a id="astpanel_custom"
-             class="btn btn-outline-primary btn-sm mr-2"
+             class="btn btn-outline-primary btn-sm"
              tal:attributes="href python:context.absolute_url() + '/ast_panel'"
-             i18n:translate="">Custom ...</a>
-
-          <a class="btn btn-outline-secondary btn-sm mr-2"
+             i18n:translate="">Customize</a>
+        </div>
+        <div class="input-group-append">
+          <a class="btn btn-outline-secondary btn-sm"
              tal:attributes="href python:context.absolute_url() + '/ast_reporting'"
              i18n:translate="">Selective reporting</a>
-
         </div>
-      </form>
-    </div>
+      </div>
+    </form>
   </div>
 
   <!-- Results entry listing -->


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request improves the styling of the AST Panel selector, following same styling as https://github.com/senaite/senaite.core/pull/1938

## Current behavior before PR

![Captura de 2022-02-16 23-03-31](https://user-images.githubusercontent.com/832627/154365655-e503a4e1-143c-4c15-9445-1a3069b78a3a.png)

## Desired behavior after PR is merged

![Captura de 2022-02-16 23-02-50](https://user-images.githubusercontent.com/832627/154365675-c27c16ee-892b-4f5d-bd9e-a31bbc4c146b.png)


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
