### PR TITLE
Fix sensitivity category is wrong when microorganism group is used for matches in breakpoints table

### DIFF
--- a/src/senaite/ast/utils.py
+++ b/src/senaite/ast/utils.py
@@ -497,17 +497,16 @@ def get_breakpoint(breakpoints_table, microorganism, antibiotic):
     if not breakpoints:
         return {}
 
+    # Look for the breakpoint for this specific microorganism
     microorganism_uid = api.get_uid(microorganism)
     for val in breakpoints:
         if val.get("microorganism") == microorganism_uid:
             return copy.deepcopy(val)
 
-    # Breakpoints table can either map to microorganism or category, but
-    # breakpoint for microorganism always have priority over the breakpoint set
-    # for the category the microorganism belongs to
+    # Look for the breakpoint for the category this microorganism belongs to
     microorganism = api.get_object(microorganism)
     category_uid = microorganism.category and microorganism.category[0] or ""
-    for val in break_obj.breakpoints:
+    for val in breakpoints:
         if val.get("microorganism") == category_uid:
             return copy.deepcopy(val)
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

A Breakpoints table can have breakpoints defined either for microorganisms and/or for microorganism groups: [Allow user to choose microorganism groups in breakpoints tables #4](https://github.com/senaite/senaite.ast/pull/4. This makes the creation of breakpoints tables less cumbersome. These breakpoints are used later to automatically calculate the sensitivity category when the zone size (mm) is entered for a given antibiotic and microorganism. Since breakpoints table accept either microorganisms and microorganism groups, system must first look for a microorganism-specific breakpoint, with a fallback to the group-specific breakpoint.

With this Pull Request, the calculation of the sensitivity category (R/I/S) is done correctly when a microorganism group is used to deduce the breakpoints, instead of the specific microorganism. System was picking the first breakpoint for the given group, without taking the antibiotic into consideration.

## Current behavior before PR

When there is no specific breakpoint for the microorganism, but for the group, the sensitivity category is not calculated correctly. 

## Desired behavior after PR is merged

When there is no specific breakpoint for the microorganism, but for the group, the sensitivity category is calculated correctly

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
