### PR TITLE
Some AST analyses had missing result options

### DIFF
--- a/src/senaite/ast/calc.py
+++ b/src/senaite/ast/calc.py
@@ -212,11 +212,13 @@ def update_extrapolated_antibiotics(analysis):
 
     # Update the analysis that stores the sensitivity category
     sensitivity = analyses.get(RESISTANCE_KEY)
-    update_extrapolated(sensitivity)
+    if sensitivity:
+        update_extrapolated(sensitivity)
 
     # Update the analysis that stores the reporting criteria (Y/N)
     reporting = analyses.get(REPORT_KEY)
-    update_extrapolated(reporting)
+    if reporting:
+        update_extrapolated(reporting)
 
 
 def update_sensitivity_result(analysis):
@@ -233,6 +235,8 @@ def update_sensitivity_result(analysis):
     # We only do report results from the analysis (Sensitivity) "Category",
     # that are stored as values (R/I/S) for interim fields (antibiotics)
     sensitivity = analyses.get(RESISTANCE_KEY)
+    if not sensitivity:
+        return
 
     # Extract the antibiotics (as interim fields) to be reported
     reportable = get_reportable_antibiotics(sensitivity)

--- a/src/senaite/ast/utils.py
+++ b/src/senaite/ast/utils.py
@@ -254,13 +254,15 @@ def get_result_options(analysis):
         full_name = interim_field.get("full_title")
 
         text = interim_choice.split(":")
-        if len(text) > 1:
-            result_text = "{}: {}".format(full_name, text[1].strip())
+        if len(text) > 0:
+            interim_value = text[0]
+            result_text = len(text) > 1 and text[1].strip() or ""
+            result_text = "{}: {}".format(full_name, result_text)
             value = {
                 "ResultText": result_text,
                 "ResultValue": result_value,
                 "InterimKeyword": abbreviation,
-                "InterimValue": text[0],
+                "InterimValue": interim_value,
             }
         return value
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes missing options from AST analyses.

## Current behavior before PR

Some AST analyses do not have valid result options set

## Desired behavior after PR is merged

AST analyses do have valid result options set

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
