### PR TITLE
Fix cannot manually remove antibiotic from an antibiotic sensitivity panel

### DIFF
--- a/src/senaite/ast/browser/panel.py
+++ b/src/senaite/ast/browser/panel.py
@@ -102,6 +102,8 @@ class ASTPanelView(ListingView):
         """
         form = self.request.form
 
+        import pdb;pdb.set_trace()
+
         # Key uids are antibiotics (columns)
         uids = filter(api.is_uid, form.keys())
         antibiotics = map(self.get_object, uids)
@@ -279,9 +281,13 @@ class ASTPanelView(ListingView):
         return utils.get_antibiotics(analyses, filter_criteria=is_required)
 
     def has_antibiotic(self, analysis, antibiotic):
-        """Returns whether the analysis has the specified antibiotic assigned
+        """Returns whether the analysis has the specified antibiotic assigned.
+        Extrapolated antibiotics are not considered
         """
         for interim in analysis.getInterimFields():
+            if utils.is_extrapolated_interim(interim):
+                # Skip extrapolated antibiotics
+                continue
             if interim.get("keyword") == antibiotic.abbreviation:
                 return True
         return False

--- a/src/senaite/ast/browser/panel.py
+++ b/src/senaite/ast/browser/panel.py
@@ -102,8 +102,6 @@ class ASTPanelView(ListingView):
         """
         form = self.request.form
 
-        import pdb;pdb.set_trace()
-
         # Key uids are antibiotics (columns)
         uids = filter(api.is_uid, form.keys())
         antibiotics = map(self.get_object, uids)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes the AST panel edit view so user can remove antibiotics correctly

## Current behavior before PR

1. Would like to remove SXT from the staph panel as it is not available for testing and result can't be submitted with a blank zone diameter. 

2. Select customise to remove antibiotic. 
![image](https://user-images.githubusercontent.com/60370593/172162406-5d0fa97e-96a4-41c5-9553-3044da1468e7.png)

3. Deselect SXT. 
![image](https://user-images.githubusercontent.com/60370593/172162896-655ac11b-bc10-4ad0-9152-a53eb89befad.png)

4. Once saved, SXT is still available as a result and extrapolated have now been introduced as individual columns. 
![image](https://user-images.githubusercontent.com/60370593/172163110-e8049521-e85e-4531-a90c-6b95dd7c46d4.png)

## Desired behavior after PR is merged

- SXT is removed when customise panel. 
- Extrapolated antibiotics are not introduced as individial columns. 

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
