### PR TITLE
Fix 'zone size' and 'report' are not available when second AST panel is added

### DIFF
--- a/src/senaite/ast/browser/panel.py
+++ b/src/senaite/ast/browser/panel.py
@@ -102,6 +102,8 @@ class ASTPanelView(ListingView):
         """
         form = self.request.form
 
+        import pdb;pdb.set_trace()
+
         # Key uids are antibiotics (columns)
         uids = filter(api.is_uid, form.keys())
         antibiotics = map(self.get_object, uids)
@@ -279,9 +281,13 @@ class ASTPanelView(ListingView):
         return utils.get_antibiotics(analyses, filter_criteria=is_required)
 
     def has_antibiotic(self, analysis, antibiotic):
-        """Returns whether the analysis has the specified antibiotic assigned
+        """Returns whether the analysis has the specified antibiotic assigned.
+        Extrapolated antibiotics are not considered
         """
         for interim in analysis.getInterimFields():
+            if utils.is_extrapolated_interim(interim):
+                # Skip extrapolated antibiotics
+                continue
             if interim.get("keyword") == antibiotic.abbreviation:
                 return True
         return False

--- a/src/senaite/ast/browser/panel.py
+++ b/src/senaite/ast/browser/panel.py
@@ -102,8 +102,6 @@ class ASTPanelView(ListingView):
         """
         form = self.request.form
 
-        import pdb;pdb.set_trace()
-
         # Key uids are antibiotics (columns)
         uids = filter(api.is_uid, form.keys())
         antibiotics = map(self.get_object, uids)

--- a/src/senaite/ast/browser/panel.py
+++ b/src/senaite/ast/browser/panel.py
@@ -148,7 +148,7 @@ class ASTPanelView(ListingView):
         else:
             # Update analyses
             for analysis in analyses:
-                self.update_analysis(analysis, antibiotics)
+                utils.update_ast_analysis(analysis, antibiotics, purge=True)
 
     def can_delete(self, analysis):
         """Returns whether the analysis can be removed or not
@@ -164,25 +164,6 @@ class ASTPanelView(ListingView):
                 return False
 
         return True
-
-    def update_analysis(self, analysis, antibiotics):
-        """Updates the analysis with the antibiotics
-        """
-        if ISubmitted.providedBy(analysis):
-            noLongerProvides(analysis, ISubmitted)
-
-        if IVerified.providedBy(analysis):
-            noLongerProvides(analysis, IVerified)
-
-        # Rollback to assigned/unassigned status
-        to_rollback = ["verified", "to_be_verified"]
-        if api.get_review_status(analysis) in to_rollback:
-            get_prev_status = api.get_previous_worfklow_status_of
-            prev_status = get_prev_status(analysis, skip=to_rollback)
-            changeWorkflowState(analysis, ANALYSIS_WORKFLOW, prev_status)
-
-        # Update the analysis with the antibiotics
-        utils.update_ast_analysis(analysis, antibiotics, purge=True)
 
     def redirect(self, message=None, level="info"):
         """Redirect with a message

--- a/src/senaite/ast/browser/panel.py
+++ b/src/senaite/ast/browser/panel.py
@@ -24,7 +24,6 @@ from bika.lims import api
 from bika.lims.catalog import SETUP_CATALOG
 from bika.lims.interfaces import ISubmitted
 from bika.lims.interfaces import IVerified
-from bika.lims.utils import changeWorkflowState
 from bika.lims.utils import get_link_for
 from plone.memoize import view
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
@@ -34,8 +33,6 @@ from senaite.ast import utils
 from senaite.ast.config import BREAKPOINTS_TABLE_KEY
 from senaite.ast.config import RESISTANCE_KEY
 from senaite.ast.config import ZONE_SIZE_KEY
-from senaite.core.workflow import ANALYSIS_WORKFLOW
-from zope.interface import noLongerProvides
 
 
 class ASTPanelView(ListingView):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

**Please merge https://github.com/senaite/senaite.ast/pull/18 first**

This Pull Request ensures the options "zone size" and "report" are correctly displayed in sensitivity results entry when a second panel is added after the analyses from first panel have been submitted.

## Current behavior before PR

First panel of antibiotics are tested.
<img width="520" alt="image" src="https://user-images.githubusercontent.com/82001708/170334985-3176d8f2-0102-42a3-8c4b-71ea654fe25c.png">

Found to be resistant so further antibiotic panel is added.
<img width="478" alt="image" src="https://user-images.githubusercontent.com/82001708/170336481-feab6177-e463-4406-9bff-2130cba33fd8.png">

However when additional SST panel is added you are not given the option of adding zone size or report. 

Steps to replicate issue: 

1. Add GNB1 panel and enter zone sizes/report options. Save and submit.
2. 
![image](https://user-images.githubusercontent.com/60370593/171604596-88832447-48f4-469a-ba6d-1a97ac180867.png)

3. Add GNB2 panel. Unable to enter zone diameters and report options. 

![image](https://user-images.githubusercontent.com/60370593/171604803-c610ec34-ba84-4c52-aabe-745cb832ae7c.png)

## Desired behavior after PR is merged

User should be able to enter zone diameters and report options when second new panel is added. 

![Captura de 2022-06-14 13-16-35](https://user-images.githubusercontent.com/832627/173565127-3781f657-7067-4d3e-a3a1-1966fd5e0666.png)


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
