### PR TITLE
Compatibility with senaite.app.listing#87

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 1.1.0 (unreleased)
 ------------------
 
+- #20 Compatibility with senaite.app.listing#87
 
 1.0.0 (2022-06-18)
 ------------------

--- a/src/senaite/ast/browser/templates/ast_results.pt
+++ b/src/senaite/ast/browser/templates/ast_results.pt
@@ -71,6 +71,7 @@
     <div class="ajax-contents-table w-100"
          tal:attributes="data-form_id python:view.form_id;
                          data-listing_identifier python:view.listing_identifier;
+                         data-enable_ajax_transitions python:view.ajax_transitions_enabled();
                          data-pagesize python:view.pagesize;
                          data-api_url python:view.get_api_url();
                          data-columns python:view.ajax_columns();


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes senaite.ast compatible with the changes introduced in https://github.com/senaite/senaite.app.listing/pull/87

## Current behavior before PR

The table for AST/AMR results introduction is not displayed

## Desired behavior after PR is merged

The table for AST/AMR results introduction is displayed correctly

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
