### PR TITLE
Fix AST entry is empty when analyses categorization for sample is checked

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 1.1.0 (unreleased)
 ------------------
 
+- #21 Fix AST entry is empty when analyses categorization for sample is checked
 - #20 Compatibility with senaite.app.listing#87
 
 1.0.0 (2022-06-18)

--- a/src/senaite/ast/browser/results.py
+++ b/src/senaite/ast/browser/results.py
@@ -94,6 +94,12 @@ class ManageResultsView(AnalysesView):
         obj = api.get_object(service_uid_brain_object)
         return api.get_id(obj)
 
+    def analysis_categories_enabled(self):
+        """Returns false, as analyses for AST results entry cannot be
+        categorized, cause all them are computed
+        """
+        return False
+
     def folderitem(self, obj, item, index):
         keyword = obj.getKeyword
         item["Keyword"] = keyword


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures that the listing for results entry is not empty when the setting *Categorize sample analyses* introduced with https://github.com/senaite/senaite.core/pull/2140 is selected

## Current behavior before PR

The listing for the introduction of AST results is empty when the setting *Categorize sample analyses* from setup is selected

![Captura de 2023-03-11 19-14-30](https://user-images.githubusercontent.com/832627/224504954-b67997ba-76cc-4803-84b9-e89f34a1c075.png)


## Desired behavior after PR is merged

The listing for the introduction of AST results is not empty when the setting *Categorize sample analyses* from setup is selected

![Captura de 2023-03-11 19-13-28](https://user-images.githubusercontent.com/832627/224504923-06c37484-9de8-412b-801a-7406aee6741a.png)


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
