### PR TITLE
Hide Unit and display Submitter before Captured in AST entry

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 1.1.0 (unreleased)
 ------------------
 
+- #22 Hide Unit and display Submitter before Captured in AST entry
 - #21 Fix AST entry is empty when analyses categorization for sample is checked
 - #20 Compatibility with senaite.app.listing#87
 

--- a/src/senaite/ast/browser/results.py
+++ b/src/senaite/ast/browser/results.py
@@ -204,7 +204,7 @@ class ManageResultsView(AnalysesView):
             for state in self.review_states:
                 # Resort interim fields
                 columns = state["columns"]
-                position = columns.index("CaptureDate")
+                position = columns.index("Service") + 1
                 for col_id in interim_keys:
                     if col_id not in columns:
                         columns.insert(position, col_id)

--- a/src/senaite/ast/browser/results.py
+++ b/src/senaite/ast/browser/results.py
@@ -82,7 +82,7 @@ class ManageResultsView(AnalysesView):
         # Remove the columns we are not interested in from review_states
         hide = ["Method", "Instrument", "Analyst", "DetectionLimitOperand",
                 "Specification", "Uncertainty", "retested", "Attachments",
-                "DueDate", "Result", "Hidden"]
+                "DueDate", "Result", "Hidden", "Unit"]
 
         all_columns = self.columns.keys()
         all_columns = filter(lambda c: c not in hide, all_columns)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request hides the "Unit" column introduced with https://github.com/senaite/senaite.core/pull/2201 and moves the existing "Submitter" column just before the "Captured" column.

## Current behavior before PR

![Captura de 2023-03-11 19-58-43](https://user-images.githubusercontent.com/832627/224506720-40081080-8fe8-4c7a-93e3-97ef56414ccc.png)

## Desired behavior after PR is merged

![Captura de 2023-03-11 19-57-54](https://user-images.githubusercontent.com/832627/224506725-1504c4ec-0501-4c69-9b14-8fd917c392e1.png)


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
