### PR TITLE
Fix AST calculation does not work when extrapolated antibiotics

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 1.1.0 (unreleased)
 ------------------
 
+- #23 Fix AST calculation does not work when extrapolated antibiotics
 - #22 Hide Unit and display Submitter before Captured in AST entry
 - #21 Fix AST entry is empty when analyses categorization for sample is checked
 - #20 Compatibility with senaite.app.listing#87

--- a/src/senaite/ast/calc.py
+++ b/src/senaite/ast/calc.py
@@ -311,7 +311,7 @@ def get_reportable_antibiotics(analysis):
         if primary:
             # Check if the primary is reportable
             uid = interim.get("uid")
-            return uid in reportable.get(primary)
+            return uid in reportable.get(primary, [])
         return interim.get("value") == "1"
 
     # The analysis "Report" is used to identify the results from the sensitivity


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The calculation does not work properly for resistance test when at least one of the antibiotics selected in the AST panel have extrapolated antibiotics assigned

Linked issue: https://github.com/senaite/senaite.ast/issues/

## Current behavior before PR

The result of the analysis is not updated correctly (default's '-' is kept) and the following error happens silently (because senaite.core calculate func does not inform about the error).

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module senaite.app.listing.view, line 248, in __call__
  Module senaite.app.listing.ajax, line 113, in handle_subpath
  Module senaite.app.listing.decorators, line 63, in wrapper
  Module senaite.app.listing.decorators, line 50, in wrapper
  Module senaite.app.listing.decorators, line 100, in wrapper
  Module senaite.app.listing.ajax, line 647, in ajax_set_fields
  Module senaite.app.listing.ajax, line 432, in set_field
  Module senaite.core.datamanagers.analysis, line 112, in set
  Module senaite.ast.datamanagers, line 38, in recalculate_results
  Module senaite.core.datamanagers.analysis, line 130, in recalculate_results
  Module bika.lims.content.abstractanalysis, line 613, in calculateResult
TypeError: argument of type 'NoneType' is not iterable
```

## Desired behavior after PR is merged

AST calculation is performed correctly and the result for resistance analysis is updated as well

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
