### PR TITLE
Do not allow to "submit" AST analyses with no result saved

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 1.1.0 (unreleased)
 ------------------
 
+- #25 Do not allow to "submit" AST analyses with no result save
 - #23 Fix AST calculation does not work when extrapolated antibiotics
 - #22 Hide Unit and display Submitter before Captured in AST entry
 - #21 Fix AST entry is empty when analyses categorization for sample is checked

--- a/src/senaite/ast/adapters/guards.py
+++ b/src/senaite/ast/adapters/guards.py
@@ -89,21 +89,24 @@ class AnalysisGuardAdapter(BaseGuardAdapter):
             # Not an AST analysis
             return True
 
-        # Check that all interim fields have non-empty values
-        keyword = self.context.getKeyword()
-        for interim in self.context.getInterimFields():
+        # Get the antibiotics (as interim fields)
+        antibiotics = self.context.getInterimFields()
+        if not antibiotics:
+            return False
 
-            if utils.is_extrapolated_interim(interim):
-                # Skip extrapolated interims
+        keyword = self.context.getKeyword()
+        for antibiotic in antibiotics:
+            if utils.is_extrapolated_interim(antibiotic):
+                # Skip extrapolated antibiotics
                 continue
 
-            if utils.is_interim_empty(interim):
-                # Cannot submit if empty interim
+            if utils.is_interim_empty(antibiotic):
+                # Cannot submit if no result
                 return False
 
             if keyword in [ZONE_SIZE_KEY, DISK_CONTENT_KEY]:
                 # Negative values are not permitted
-                value = interim.get("value")
+                value = antibiotic.get("value")
                 value = api.to_float(value, default=-1)
                 if value < 0:
                     return False

--- a/src/senaite/ast/adapters/guards.py
+++ b/src/senaite/ast/adapters/guards.py
@@ -97,6 +97,10 @@ class AnalysisGuardAdapter(BaseGuardAdapter):
                 # Skip extrapolated interims
                 continue
 
+            if utils.is_interim_empty(interim):
+                # Cannot submit if empty interim
+                return False
+
             if keyword in [ZONE_SIZE_KEY, DISK_CONTENT_KEY]:
                 # Negative values are not permitted
                 value = interim.get("value")
@@ -104,5 +108,4 @@ class AnalysisGuardAdapter(BaseGuardAdapter):
                 if value < 0:
                     return False
 
-        # No empties
         return True


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures that user cannot submit AST analyses without result for all antibiotics being set.

## Current behavior before PR

User can submit sensitivity results with missing values for antibiotics:

![Captura de 2023-06-21 13-20-23](https://github.com/senaite/senaite.ast/assets/832627/668ffddc-9d5c-4dff-b5fd-0c400dcc2cc5)

## Desired behavior after PR is merged

User cannot submit sensitivity results with missing values for antibiotics

![Captura de 2023-06-21 13-24-15](https://github.com/senaite/senaite.ast/assets/832627/afc93f1c-18f3-4cdc-9453-795b58920a1d)


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
