### PR TITLE
Fix Sensitivity result is not updated when selective reporting is missing

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 1.1.0 (unreleased)
 ------------------
 
+- #26 Fix Sensitivity result is not updated when selective reporting is missing
 - #23 Fix AST calculation does not work when extrapolated antibiotics
 - #22 Hide Unit and display Submitter before Captured in AST entry
 - #21 Fix AST entry is empty when analyses categorization for sample is checked


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request guarantees the sensitivity result is correctly updated when no selective reporting analysis is set, either because the AST was added manually (via "Customize" option) or because the AST Panel selected had the option "Selective reporting" set to `False`.

The reason of why this was not working as expected is because the `calc_ast` calculation was not returning the result to be set to the given analysis. Reason is that the calculation logic itself was updating the results already. When a selective reporting analysis was present, the last calculation to be called was bound to the reporting analysis itself and therefore, the results of the sensitivity were updated, and not overwritten by the calc machinery afterwards.

## Current behavior before PR

Sensitivity results are not updated (but cleared) when no selective reporting is set

## Desired behavior after PR is merged

Sensitivity results are updated when no selective reporting is set, assuming that all results must be reported

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
