### PR TITLE
Support "<" and ">" for MIC values

### DIFF
--- a/src/senaite/ast/adapters/guards.py
+++ b/src/senaite/ast/adapters/guards.py
@@ -105,9 +105,18 @@ class AnalysisGuardAdapter(BaseGuardAdapter):
                 # Cannot submit if no result
                 return False
 
-            if keyword in [ZONE_SIZE_KEY, DISK_CONTENT_KEY, MIC_KEY]:
+            if keyword in [ZONE_SIZE_KEY, DISK_CONTENT_KEY]:
                 # Negative values are not permitted
                 value = antibiotic.get("value")
+                value = api.to_float(value, default=-1)
+                if value < 0:
+                    return False
+
+            if keyword in [MIC_KEY]:
+                # Negative values are not permitted, but '<' is allowed
+                value = antibiotic.get("value")
+                if value[0] in ["<", ">"]:
+                    value = value[1:]
                 value = api.to_float(value, default=-1)
                 if value < 0:
                     return False

--- a/src/senaite/ast/browser/addpanel.py
+++ b/src/senaite/ast/browser/addpanel.py
@@ -73,7 +73,7 @@ class AddPanelView(BrowserView):
             elif panel.method == METHOD_MIC_ID:
                 # Create/Update the minimum inhibitory concentration analysis
                 if panel.mic_value:
-                    add(MIC_KEY, microorganism, antibiotics)
+                    self.add_mic_analysis(microorganism, antibiotics)
 
             # Create/Update the sensitivity result analysis
             self.add_ast_analysis(RESISTANCE_KEY, microorganism, antibiotics)
@@ -141,3 +141,15 @@ class AddPanelView(BrowserView):
         # Update each microorganism-antibiotic with suitable breakpoints table
         update_breakpoint_tables_choices(analysis, default_table=default_table)
         return analysis
+
+    def add_mic_analysis(self, microorganism, antibiotics):
+        """Updates or creates an analysis for the selection of the Minimum
+        Inhibitory Concentration (MIC) value, that allows the introduction of
+        less than '<' characters
+        """
+        mic = self.add_ast_analysis(MIC_KEY, microorganism, antibiotics)
+        interim_fields = mic.getInterimFields()
+        for interim_field in interim_fields:
+            interim_field["result_type"] = "string"
+        mic.setInterimFields(interim_fields)
+        return mic


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes possible to introduce lower-than `<` and greater-than `>` characters for MIC Value in sensitivity results entry

## Current behavior before PR

Only numbers above 0 are supported

## Desired behavior after PR is merged

Only numbers above 0 or with `<` and `>` operator at the beginning are supported

![Captura de 2023-10-11 15-21-36](https://github.com/senaite/senaite.ast/assets/832627/d1ca2f8e-7a88-4b7a-b844-17030c634a75)

![Captura de 2023-10-11 15-23-10](https://github.com/senaite/senaite.ast/assets/832627/95d0e6cf-e7c0-427e-8339-e83c0ab4373d)


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
