### PR TITLE
Fix sizes for numeric fields are too small

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 1.1.0 (unreleased)
 ------------------
 
+- #30 Fix sizes for numeric fields are too small
 - #26 Fix Sensitivity result is not updated when selective reporting is missing
 - #25 Do not allow to "submit" AST analyses with no result save
 - #23 Fix AST calculation does not work when extrapolated antibiotics

--- a/src/senaite/ast/config.py
+++ b/src/senaite/ast/config.py
@@ -139,7 +139,7 @@ SERVICES_SETTINGS = {
               u"testing results following a standardised disk diffusion "
               u"method equivalent to disk load, disk mass, disk strength, and "
               u"disk charge."),
-        "size": "1",
+        "size": "3",
         "sort_key": 510,
         "string_result": True,
         "point_of_capture": AST_POINT_OF_CAPTURE,
@@ -155,7 +155,7 @@ SERVICES_SETTINGS = {
               u"potent is the antimicrobial. It is used to determine whether "
               u"a bacteria is resistant, intermediately sensitive or "
               u"susceptible to an antibiotic."),
-        "size": "1",
+        "size": "3",
         "sort_key": 520,
         "string_result": True,
         "point_of_capture": AST_POINT_OF_CAPTURE,
@@ -171,7 +171,7 @@ SERVICES_SETTINGS = {
               u"potent the antimicrobial. It is used to determine whether a "
               u"bacteria is resistant, intermediately sensitive or "
               u"susceptible to an antibiotic."),
-        "size": "1",
+        "size": "3",
         "sort_key": 520,
         "string_result": True,
         "point_of_capture": AST_POINT_OF_CAPTURE,

--- a/src/senaite/ast/profiles/default/metadata.xml
+++ b/src/senaite/ast/profiles/default/metadata.xml
@@ -6,7 +6,7 @@
   dependencies before installing this add-on own profile.
 -->
 <metadata>
-  <version>1102</version>
+  <version>1103</version>
 
   <!-- Be sure to install the following dependencies if not yet installed -->
   <dependencies>

--- a/src/senaite/ast/upgrade/v01_01_000.zcml
+++ b/src/senaite/ast/upgrade/v01_01_000.zcml
@@ -4,6 +4,18 @@
     i18n_domain="senaite.ast">
 
   <genericsetup:upgradeStep
+      title="SENAITE AST 1.1.0: Resize of fields for numeric entry"
+      description="
+        Walks through all AST analyses of 'Disk content(μg)', 'Zone diameter
+        (mm)' and 'MIC value (μg/mL)' and resets the size of their input
+        element from '1' to '3', cause they got shrinked with
+        https://github.com/senaite/senaite.app.listing/pull/125"
+      source="1102"
+      destination="1103"
+      handler=".v01_01_000.resize_ast_numeric_fields"
+      profile="senaite.ast:default"/>
+
+  <genericsetup:upgradeStep
       title="SENAITE AST 1.1.0: Add support for MIC method"
       description="
         Adds support for the Minimum Inhibitory Concentration (MIC) method. An


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request enlarges the fields for the analyses 'Disk content(μg)', 'Zone diameter (mm)' and 'MIC value (μg/mL)', that got shrinked because of https://github.com/senaite/senaite.app.listing/pull/125

## Current behavior before PR

![Captura de 2023-10-13 13-15-07](https://github.com/senaite/senaite.ast/assets/832627/bd879ea7-c7c1-4fdc-a9ee-1e4e3f2ce724)

## Desired behavior after PR is merged

![Captura de 2023-10-13 13-15-23](https://github.com/senaite/senaite.ast/assets/832627/189541c2-5a48-4bb6-af26-049461411faf)


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
