### PR TITLE
Compatibility with senaite.core#2492 (AnalysisProfile to DX) 

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 1.2.0 (unreleased)
 ------------------
 
+- #32 Compatibility with senaite.core#2492 (AnalysisProfile to DX)
 
 1.1.0 (2024-01-04)
 ------------------

--- a/src/senaite/ast/adapters/configure.zcml
+++ b/src/senaite/ast/adapters/configure.zcml
@@ -23,8 +23,8 @@
    AST-like analyses are always added manually afterwards, based on the result
    oif the "Microorganism Identification" analysis -->
   <subscriber
-    for="bika.lims.browser.widgets.analysisprofileanalyseswidget.AnalysisProfileAnalysesView
-         bika.lims.interfaces.IAnalysisProfile"
+    for="senaite.core.browser.widgets.analysisprofileswidget.AnalysisProfilesWidget
+         senaite.core.interfaces.IAnalysisProfile"
     provides="senaite.app.listing.interfaces.IListingViewAdapter"
     factory=".listing.services.NonASTServicesViewAdapter" />
 

--- a/src/senaite/ast/upgrade/v01_00_000.py
+++ b/src/senaite/ast/upgrade/v01_00_000.py
@@ -146,12 +146,8 @@ def remove_ast_from_profiles(portal):
     """
     logger.info("Removing AST-like analyses from profiles ...")
     ast_uids = get_ast_services_uids(portal)
-    query = {
-        "portal_type": "AnalysisProfile"
-    }
-    brains = api.search(query, SETUP_CATALOG)
-    for brain in brains:
-        obj = api.get_object(brain)
+    profiles = portal.setup.analysisprofiles.objectValues()
+    for obj in profiles:
         services = obj.getRawServices() or []
         services = filter(lambda s: s.get("uid") not in ast_uids, services)
         obj.setServices(services)

--- a/src/senaite/ast/upgrade/v01_00_000.py
+++ b/src/senaite/ast/upgrade/v01_00_000.py
@@ -152,9 +152,9 @@ def remove_ast_from_profiles(portal):
     brains = api.search(query, SETUP_CATALOG)
     for brain in brains:
         obj = api.get_object(brain)
-        services = obj.getRawService() or []
-        services = filter(lambda s: s not in ast_uids, services)
-        obj.setService(services)
+        services = obj.getRawServices() or []
+        services = filter(lambda s: s.get("uid") not in ast_uids, services)
+        obj.setServices(services)
     logger.info("Removing AST-like analyses from profiles [DONE]")
 
 


### PR DESCRIPTION
## Description

> [!CAUTION]
> Merge https://github.com/senaite/senaite.core/pull/2492 first

This Pull Request makes this product compatible with [Migrate Analysis Profiles to Dexterity #2492](https://github.com/senaite/senaite.core/pull/2492)

## Current behavior

Not compatible with DX's AnalysisProfile

## Desired behavior

Compatible with DX's AnalysisProile

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
