### PR TITLE
Display the Antibiotic Sensitivity section from sample view only when necessary

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,7 @@ Changelog
 - #33 Display the Antibiotic Sensitivity section only when necessary
 - #32 Compatibility with senaite.core#2492 (AnalysisProfile to DX)
 
+
 1.1.0 (2024-01-04)
 ------------------
 
@@ -18,6 +19,7 @@ Changelog
 - #22 Hide Unit and display Submitter before Captured in AST entry
 - #21 Fix AST entry is empty when analyses categorization for sample is checked
 - #20 Compatibility with senaite.app.listing#87
+
 
 1.0.0 (2022-06-18)
 ------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 1.2.0 (unreleased)
 ------------------
 
+- #33 Display the Antibiotic Sensitivity section only when necessary
 - #32 Compatibility with senaite.core#2492 (AnalysisProfile to DX)
 
 1.1.0 (2024-01-04)

--- a/src/senaite/ast/browser/results.py
+++ b/src/senaite/ast/browser/results.py
@@ -31,6 +31,9 @@ from senaite.ast import is_installed
 from senaite.ast import messageFactory as _
 from senaite.ast import utils
 from senaite.ast.config import AST_POINT_OF_CAPTURE
+from senaite.ast.config import IDENTIFICATION_KEY
+from senaite.ast.utils import get_ast_analyses
+from senaite.ast.utils import get_identified_microorganisms
 from senaite.core.browser.viewlets.sampleanalyses import LabAnalysesViewlet
 
 
@@ -42,9 +45,24 @@ class ASTAnalysesViewlet(LabAnalysesViewlet):
     capture = AST_POINT_OF_CAPTURE
 
     def available(self):
-        """Returns true if senaite.ast is installed
+        """Returns true if senaite.ast is installed and the sample contains
+        at least one sensitivity testing analysis or the microorganism
+        identification analysis is present
         """
-        return is_installed()
+        if not is_installed():
+            return False
+
+        # does this sample has the identification analysis?
+        analyses = self.context.getAnalyses(getKeyword=IDENTIFICATION_KEY)
+        if analyses:
+            return True
+
+        # does this have sensitivity testing analyses?
+        ast_analyses = get_ast_analyses(self.context)
+        if ast_analyses:
+            return True
+
+        return False
 
 
 class ManageResultsView(AnalysesView):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures the sensitivity testing section in sample view is displayed only when the `senaite.ast` product is installed and the sample has at least one analysis for sensitivity testing and/or the analysis for the identification of microorganisms.

![Captura de 2024-03-01 16-38-01](https://github.com/senaite/senaite.ast/assets/832627/f177eead-5688-4722-8fbb-9cf935fc84ee)


## Current behavior before PR

The section for sensitivity results is always displayed

## Desired behavior after PR is merged

The section for sensitivity results is displayed only when necessary

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
