### PR TITLE
Compatibility with core#2521 - AT2DX ARTemplate/SampleTemplate

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 1.2.0 (unreleased)
 ------------------
 
+- #35 Compatibility with core#2521 - AT2DX ARTemplate/SampleTemplate
 - #34 Add transition "Reject antibiotics"
 - #33 Display the Antibiotic Sensitivity section only when necessary
 - #32 Compatibility with senaite.core#2492 (AnalysisProfile to DX)

--- a/src/senaite/ast/adapters/configure.zcml
+++ b/src/senaite/ast/adapters/configure.zcml
@@ -30,8 +30,8 @@
 
   <!-- Do not display AST-type services for selection in Analysis Template -->
   <subscriber
-    for="bika.lims.browser.widgets.artemplateanalyseswidget.ARTemplateAnalysesView
-         bika.lims.interfaces.IARTemplate"
+    for="senaite.core.browser.widgets.sampletemplate_services_widget.SampleTemplateServicesWidget
+         senaite.core.interfaces.ISampleTemplate"
     provides="senaite.app.listing.interfaces.IListingViewAdapter"
     factory=".listing.services.NonASTServicesViewAdapter" />
 

--- a/src/senaite/ast/adapters/configure.zcml
+++ b/src/senaite/ast/adapters/configure.zcml
@@ -28,7 +28,7 @@
     provides="senaite.app.listing.interfaces.IListingViewAdapter"
     factory=".listing.services.NonASTServicesViewAdapter" />
 
-  <!-- Do not display AST-type services for selection in Analysis Template -->
+  <!-- Do not display AST-type services for selection in Sample Template -->
   <subscriber
     for="senaite.core.browser.widgets.sampletemplate_services_widget.SampleTemplateServicesWidget
          senaite.core.interfaces.ISampleTemplate"

--- a/src/senaite/ast/upgrade/v01_00_000.py
+++ b/src/senaite/ast/upgrade/v01_00_000.py
@@ -33,6 +33,7 @@ from senaite.ast.setuphandlers import setup_behaviors
 from senaite.ast.setuphandlers import setup_navigation_types
 from senaite.ast.utils import get_result_options
 from senaite.core.catalog import SETUP_CATALOG
+from senaite.core.interfaces import ISampleTemplate
 from senaite.core.upgrade import upgradestep
 from senaite.core.upgrade.utils import UpgradeUtils
 
@@ -160,11 +161,18 @@ def remove_ast_from_templates(portal):
     logger.info("Removing AST-like analyses from templates ...")
     ast_uids = get_ast_services_uids(portal)
     query = {
-        "portal_type": "ARTemplate"
+        "portal_type": ["ARTemplate", "SampleTemplate"]
     }
     brains = api.search(query, SETUP_CATALOG)
     for brain in brains:
         obj = api.get_object(brain)
+        if ISampleTemplate.providedBy(obj):
+            ans = obj.getRawServices()
+            ans = filter(lambda an: an.get("uid") not in ast_uids, ans)
+            obj.setServices(list(ans))
+            continue
+
+        # Old AT object (https://github.com/senaite/senaite.core/pull/2521)
         ans = obj.getAnalyses()
         ans = filter(lambda an: an.get("service_uid") not in ast_uids, ans)
         obj.setAnalyses(ans)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes `senaite.ast` compatible with [Migrate Sample Templates to Dexterity #2521](https://github.com/senaite/senaite.core/pull/2521)

## Current behavior before PR

`senaite.ast` relies on AT ARTemplate

## Desired behavior after PR is merged

`senaite.ast` relies on DX SampleTemplate

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
