### PR TITLE
Fix user can edit ast built-in services after upgrades

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 1.2.0 (unreleased)
 ------------------
 
+- #36 Fix user can edit ast built-in services after upgrades
 - #35 Compatibility with core#2521 - AT2DX ARTemplate/SampleTemplate
 - #34 Add transition "Reject antibiotics"
 - #33 Display the Antibiotic Sensitivity section only when necessary

--- a/src/senaite/ast/profiles/default/metadata.xml
+++ b/src/senaite/ast/profiles/default/metadata.xml
@@ -6,7 +6,7 @@
   dependencies before installing this add-on own profile.
 -->
 <metadata>
-  <version>1201</version>
+  <version>1202</version>
 
   <!-- Be sure to install the following dependencies if not yet installed -->
   <dependencies>

--- a/src/senaite/ast/setuphandlers.py
+++ b/src/senaite/ast/setuphandlers.py
@@ -294,8 +294,6 @@ def revoke_edition_permissions(portal):
         security.revoke_permission_for(obj, ModifyPortalContent, roles)
         obj.reindexObject()
 
-    import pdb;pdb.set_trace()
-
     # analysis services
     query = {
         "portal_type": "AnalysisService",

--- a/src/senaite/ast/setuphandlers.py
+++ b/src/senaite/ast/setuphandlers.py
@@ -33,6 +33,7 @@ from senaite.ast.config import SERVICE_CATEGORY
 from senaite.ast.config import SERVICES_SETTINGS
 from senaite.ast.permissions import TransitionRejectAntibiotics
 from senaite.core.api.workflow import update_workflow
+from senaite.core.catalog import SETUP_CATALOG
 from senaite.core.workflow import ANALYSIS_WORKFLOW
 from zope.component import getUtility
 
@@ -102,6 +103,9 @@ def setup_handler(context):
 
     # setup workflows
     setup_workflows(portal)
+
+    # Revoke edit permissions for ast setup objects
+    revoke_edition_permissions(portal)
 
     logger.info("{} setup handler [DONE]".format(PRODUCT_NAME.upper()))
 
@@ -277,6 +281,35 @@ def remove_behaviors(portal):
         fti.behaviors = tuple(orig_behaviors)
 
     logger.info("Removing Behaviors [DONE]")
+
+
+def revoke_edition_permissions(portal):
+    """Revoke the 'Modify portal content' permission to 'ast' services
+    """
+    logger.info("Revoking edition permissions to AST setup objects ...")
+
+    def revoke_permission(obj):
+        obj = api.get_object(obj)
+        roles = security.get_valid_roles_for(obj)
+        security.revoke_permission_for(obj, ModifyPortalContent, roles)
+        obj.reindexObject()
+
+    import pdb;pdb.set_trace()
+
+    # analysis services
+    query = {
+        "portal_type": "AnalysisService",
+        "point_of_capture": AST_POINT_OF_CAPTURE
+    }
+    brains = api.search(query, SETUP_CATALOG)
+    map(revoke_permission, brains)
+
+    # calculation
+    query = {"portal_type": "Calculation", "title": AST_CALCULATION_TITLE}
+    brains = api.search(query, SETUP_CATALOG)
+    map(revoke_permission, brains)
+
+    logger.info("Revoking edition permissions to AST setup objects [DONE]")
 
 
 def search_by_title(container, title):

--- a/src/senaite/ast/subscribers/upgrade.py
+++ b/src/senaite/ast/subscribers/upgrade.py
@@ -23,6 +23,7 @@ from bika.lims.api import get_portal
 from senaite.ast import is_installed
 from senaite.ast import logger
 from senaite.ast import PRODUCT_NAME
+from senaite.ast.setuphandlers import revoke_edition_permissions
 from senaite.ast.setuphandlers import setup_behaviors
 from senaite.ast.setuphandlers import setup_navigation_types
 from senaite.ast.setuphandlers import setup_workflows
@@ -51,5 +52,8 @@ def afterUpgradeStepHandler(event):
 
     # Setup workflows
     setup_workflows(portal)
+
+    # Revoke edit permissions for ast setup objects
+    revoke_edition_permissions(portal)
 
     logger.info("Run {}.afterUpgradeStepHandler [DONE]".format(PRODUCT_NAME))

--- a/src/senaite/ast/upgrade/v01_02_000.py
+++ b/src/senaite/ast/upgrade/v01_02_000.py
@@ -22,6 +22,7 @@ from bika.lims import api
 from senaite.ast import logger
 from senaite.ast import PRODUCT_NAME
 from senaite.ast.config import AST_POINT_OF_CAPTURE
+from senaite.ast.setuphandlers import revoke_edition_permissions
 from senaite.ast.setuphandlers import setup_workflows
 from senaite.core.catalog import ANALYSIS_CATALOG
 from senaite.core.upgrade import upgradestep
@@ -85,3 +86,8 @@ def update_role_mappings_for(object_or_brain):
         wf = tool.getWorkflowById(wf_id)
         wf.updateRoleMappingsFor(obj)
         obj.reindexObject(idxs=["allowedRolesAndUsers"])
+
+
+def revoke_setup_permissions(tool):
+    portal = tool.aq_inner.aq_parent
+    revoke_edition_permissions(portal)

--- a/src/senaite/ast/upgrade/v01_02_000.zcml
+++ b/src/senaite/ast/upgrade/v01_02_000.zcml
@@ -3,6 +3,14 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
   <genericsetup:upgradeStep
+      title="SENAITE AST 1.2.0: Revoke edit permissions for AST setup objects"
+      description="Revoke edit permissions for AST setup objects"
+      source="1201"
+      destination="1202"
+      handler="senaite.ast.upgrade.v01_02_000.revoke_setup_permissions"
+      profile="senaite.ast:default"/>
+
+  <genericsetup:upgradeStep
       title="SENAITE AST 1.2.0: Setup transition for antibiotic rejection"
       description="Setup transition for antibiotic rejection"
       source="1200"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request revokes the `Modify Portal Content` permissions for built-in AST setup objects.

Linked issue: https://github.com/senaite/senaite.ast/issues/

## Current behavior before PR

Built-in AST setup objects become editable after a regular upgrade of senaite.core

## Desired behavior after PR is merged

Built-in AST setup objects are kept uneditable after a regular upgrade of senaite.core

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
