### PR TITLE
Compatibility with senaite.core #2595

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 1.2.0 (unreleased)
 ------------------
 
+- #38 Compatibility with core#2595 (Move ARAnalysesField logic to data manager)
 - #37 Compatibility with core#2567 (AnalysisCategory to DX)
 - #37 Compatibility with core#2471 (Department to DX)
 - #36 Fix user can edit ast built-in services after upgrades

--- a/src/senaite/ast/datamanagers.py
+++ b/src/senaite/ast/datamanagers.py
@@ -27,7 +27,7 @@ from senaite.ast.interfaces import IASTAnalysis
 from senaite.ast.utils import get_ast_siblings
 from senaite.ast.utils import is_ast_analysis
 from senaite.ast.utils import is_interim_editable
-from senaite.core.datamanagers.analysis import RoutineAnalysisDataManager
+from senaite.core.datamanagers import RoutineAnalysisDataManager
 from zope.component import adapter
 
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Compatibility with https://github.com/senaite/senaite.core/pull/2595

## Current behavior before PR

Data manager imported from `from senaite.core.datamanagers.analysis`

## Desired behavior after PR is merged

Data manager imported from `from senaite.core.datamanagers`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
