### PR TITLE
Slanted panel headers

### DIFF
--- a/src/senaite/ast/browser/panel.py
+++ b/src/senaite/ast/browser/panel.py
@@ -177,7 +177,7 @@ class ASTPanelView(ListingView):
         for antibiotic in self.get_antibiotics():
             uid = api.get_uid(antibiotic)
             self.columns[uid] = {
-                "title": antibiotic.abbreviation,
+                "title": antibiotic.title,
                 "type": "boolean",
             }
         self.review_states[0]["columns"] = self.columns.keys()

--- a/src/senaite/ast/browser/static/bundles/senaite.ast.custom.css
+++ b/src/senaite/ast/browser/static/bundles/senaite.ast.custom.css
@@ -1,0 +1,29 @@
+#panel_customizer table th {
+    height: 140px;
+    width: 50px;
+    position: relative;
+    padding: 0;
+    vertical-align: bottom;
+}
+
+#panel_customizer table th:not(:first-child) {
+    overflow: visible; /* make sure rotated content isn't clipped */
+}
+
+#panel_customizer table th:not(:first-child):hover {
+    background-color: transparent !important;
+    text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5);
+}
+
+#panel_customizer table th:not(:first-child) span {
+    display: inline-block;
+    transform: translateX(50%) rotate(310deg); /* translate(0px, 0px) */
+    transform-origin: bottom left;
+    white-space: nowrap;
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    border-bottom: 1px solid gray;
+    padding-bottom: 2px; /* optional spacing between text and border */
+    width: 140px; /* match visual slant length */
+}

--- a/src/senaite/ast/browser/static/bundles/senaite.ast.custom.css
+++ b/src/senaite/ast/browser/static/bundles/senaite.ast.custom.css
@@ -15,14 +15,21 @@
     text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5);
 }
 
+/* to correclly align the text  use
+transform: translate(30px, 0px) rotate(310deg);
+or 
+transform: translateX(25%) rotate(310deg);
+or 
+ left: 35px;
+*/
 #panel_customizer table th:not(:first-child) span {
     display: inline-block;
-    transform: translateX(50%) rotate(310deg); /* translate(0px, 0px) */
+    transform: rotate(310deg); /* translate(30px, 0px) or translateX(25%) */ 
     transform-origin: bottom left;
     white-space: nowrap;
     position: absolute;
     bottom: 0;
-    left: 0;
+    left: 35px; /* 35px to position the text */
     border-bottom: 1px solid gray;
     padding-bottom: 2px; /* optional spacing between text and border */
     width: 140px; /* match visual slant length */

--- a/src/senaite/ast/browser/static/resources.pt
+++ b/src/senaite/ast/browser/static/resources.pt
@@ -1,1 +1,3 @@
-<script tal:attributes="src string:${view/site_url}//++plone++senaite.ast.static/bundles/senaite.ast.js"></script><link href="#" rel="stylesheet" tal:attributes="href string:${view/site_url}//++plone++senaite.ast.static/bundles/senaite.ast.5e0568240a9f397d2c58.css"/>
+<script tal:attributes="src string:${view/site_url}//++plone++senaite.ast.static/bundles/senaite.ast.js"></script>
+<link href="#" rel="stylesheet" tal:attributes="href string:${view/site_url}//++plone++senaite.ast.static/bundles/senaite.ast.5e0568240a9f397d2c58.css"/>
+<link href="#" rel="stylesheet" tal:attributes="href string:${view/site_url}//++plone++senaite.ast.static/bundles/senaite.ast.custom.css"/>

--- a/src/senaite/ast/browser/templates/ast_panel.pt
+++ b/src/senaite/ast/browser/templates/ast_panel.pt
@@ -17,13 +17,14 @@
     </metal:title>
 
     <metal:core fill-slot="content-core">
-
       <form class="form"
             name="ast_panel"
             action="ast_panel"
             method="POST">
 
-        <div tal:content="structure view/contents_table"></div>
+        <div id="panel_customizer">
+          <div tal:content="structure view/contents_table"></div>
+        </div>
 
         <div tal:condition="python: view.can_add_analyses()">
             <!-- Hidden Fields -->


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
The AST Panel is showing column headers with antibiotic abbreviations that are hard to grasp their meaning for users

## Current behavior before PR
The AST Panel is showing ABX abbreviations in column header 

## Desired behavior after PR is merged
The AST Panel will show ABX titles in column headers
The ABX titles in column headers will be slanted so as to prevent taking a lot of space but minimal

![image](https://github.com/user-attachments/assets/83eb5dd6-1a54-4300-84e5-54681b9d878b)

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
