### PR TITLE
Ensure full view reload after submitting 'Microorganism Identification' analysis

### DIFF
--- a/src/senaite/ast/adapters/configure.zcml
+++ b/src/senaite/ast/adapters/configure.zcml
@@ -1,67 +1,7 @@
-<configure
-  xmlns="http://namespaces.zope.org/zope"
-  i18n_domain="senaite.ast">
+<configure xmlns="http://namespaces.zope.org/zope">
 
-  <!-- AST Panel listing customization form in Sample view. Adds the filter
-   button Identified microorganisms and makes it the default filter -->
-  <subscriber
-    for="senaite.ast.browser.panel.ASTPanelView
-         bika.lims.interfaces.IAnalysisRequest"
-    provides="senaite.app.listing.interfaces.IListingViewAdapter"
-    factory=".listing.astpanel.ASTPanelViewAdapter" />
-
-  <!-- Antibiotics listing customization -->
-  <subscriber
-    for="senaite.abx.browser.content.antibioticfolder.AntibioticFolderView
-         *"
-    provides="senaite.app.listing.interfaces.IListingViewAdapter"
-    factory=".listing.antibiotics.AntibioticsListingViewAdapter" />
-
-  <!-- Do not display AST-type services for selection in Analysis Profile
-   AST analyses should never be available for selection in Analyses Profiles,
-   because identified organisms from a sample are not known beforehand. Thus,
-   AST-like analyses are always added manually afterwards, based on the result
-   oif the "Microorganism Identification" analysis -->
-  <subscriber
-    for="senaite.core.browser.widgets.analysisprofileswidget.AnalysisProfilesWidget
-         senaite.core.interfaces.IAnalysisProfile"
-    provides="senaite.app.listing.interfaces.IListingViewAdapter"
-    factory=".listing.services.NonASTServicesViewAdapter" />
-
-  <!-- Do not display AST-type services for selection in Sample Template -->
-  <subscriber
-    for="senaite.core.browser.widgets.sampletemplate_services_widget.SampleTemplateServicesWidget
-         senaite.core.interfaces.ISampleTemplate"
-    provides="senaite.app.listing.interfaces.IListingViewAdapter"
-    factory=".listing.services.NonASTServicesViewAdapter" />
-
-  <!-- Do not display AST-type services for selection in Analysis Specs
-   Validity ranges (specifications) do not apply to AST-like tests -->
-  <subscriber
-    for="bika.lims.browser.widgets.analysisspecificationwidget.AnalysisSpecificationView
-         bika.lims.interfaces.IAnalysisSpec"
-    provides="senaite.app.listing.interfaces.IListingViewAdapter"
-    factory=".listing.services.NonASTServicesViewAdapter" />
-
-  <!-- Do not display AST-type analyses in Sample's Manage analyses view
-   These type of analyses must only be handled through the Customize... option
-   next to the AST Panel selector, above the results entry listing -->
-  <subscriber
-    for="bika.lims.browser.analysisrequest.manage_analyses.AnalysisRequestAnalysesView
-         bika.lims.interfaces.IAnalysisRequest"
-    provides="senaite.app.listing.interfaces.IListingViewAdapter"
-    factory=".listing.analysisrequest.ManageAnalysesViewAdapter" />
-
-  <!-- Do not display AST-type analyses for selection in Worksheet's Add
-    Analyses view. Default senaite layout of worksheets does not work for the
-    introduction of AST results for multiple Samples at once. Therefore, the
-    submission of AST analyses must be done individually, sample by sample,
-    unless an AST-type worksheet with a suitable layout is added -->
-  <subscriber
-    for="bika.lims.browser.worksheet.views.AddAnalysesView
-         bika.lims.interfaces.IWorksheet"
-    provides="senaite.app.listing.interfaces.IListingViewAdapter"
-    factory=".listing.worksheet.AddAnalysesViewAdapter" />
+  <!-- Package includes -->
+  <include package=".listing"/>
 
   <!-- Guard handler for AnalysisRequest (aka Sample) content type -->
   <adapter

--- a/src/senaite/ast/adapters/listing/analyses.py
+++ b/src/senaite/ast/adapters/listing/analyses.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.AST.
+#
+# SENAITE.AST is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free
+# Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2020-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from senaite.app.listing.interfaces import IListingView
+from senaite.app.listing.interfaces import IListingViewAdapter
+from senaite.ast.config import IDENTIFICATION_KEY
+from zope.component import adapter
+from zope.interface import implementer
+
+@implementer(IListingViewAdapter)
+@adapter(IListingView)
+class AnalysesViewAdapter(object):
+    """Adapter for analyses listing
+    """
+
+    def __init__(self, listing, context):
+        self.listing = listing
+        self.context = context
+
+    def folder_item(self, obj, item, index):
+        keyword = obj.getKeyword
+        if keyword == IDENTIFICATION_KEY:
+            # reload the current view on analysis submit to make the section
+            # for the selection of AST panels to become visible and properly
+            # populated with panels that include at least one of the selected
+            # microorganisms
+            item["reload"] = ["submit"]
+
+    def before_render(self):
+        pass

--- a/src/senaite/ast/adapters/listing/configure.zcml
+++ b/src/senaite/ast/adapters/listing/configure.zcml
@@ -1,0 +1,64 @@
+<configure xmlns="http://namespaces.zope.org/zope">
+
+  <!-- AST Panel listing customization form in Sample view. Adds the filter
+   button Identified microorganisms and makes it the default filter -->
+  <subscriber
+    for="senaite.ast.browser.panel.ASTPanelView
+         bika.lims.interfaces.IAnalysisRequest"
+    provides="senaite.app.listing.interfaces.IListingViewAdapter"
+    factory=".astpanel.ASTPanelViewAdapter" />
+
+  <!-- Antibiotics listing customization -->
+  <subscriber
+    for="senaite.abx.browser.content.antibioticfolder.AntibioticFolderView
+         *"
+    provides="senaite.app.listing.interfaces.IListingViewAdapter"
+    factory=".antibiotics.AntibioticsListingViewAdapter" />
+
+  <!-- Do not display AST-type services for selection in Analysis Profile
+   AST analyses should never be available for selection in Analyses Profiles,
+   because identified organisms from a sample are not known beforehand. Thus,
+   AST-like analyses are always added manually afterwards, based on the result
+   oif the "Microorganism Identification" analysis -->
+  <subscriber
+    for="senaite.core.browser.widgets.analysisprofileswidget.AnalysisProfilesWidget
+         senaite.core.interfaces.IAnalysisProfile"
+    provides="senaite.app.listing.interfaces.IListingViewAdapter"
+    factory=".services.NonASTServicesViewAdapter" />
+
+  <!-- Do not display AST-type services for selection in Sample Template -->
+  <subscriber
+    for="senaite.core.browser.widgets.sampletemplate_services_widget.SampleTemplateServicesWidget
+         senaite.core.interfaces.ISampleTemplate"
+    provides="senaite.app.listing.interfaces.IListingViewAdapter"
+    factory=".services.NonASTServicesViewAdapter" />
+
+  <!-- Do not display AST-type services for selection in Analysis Specs
+   Validity ranges (specifications) do not apply to AST-like tests -->
+  <subscriber
+    for="bika.lims.browser.widgets.analysisspecificationwidget.AnalysisSpecificationView
+         bika.lims.interfaces.IAnalysisSpec"
+    provides="senaite.app.listing.interfaces.IListingViewAdapter"
+    factory=".services.NonASTServicesViewAdapter" />
+
+  <!-- Do not display AST-type analyses in Sample's Manage analyses view
+   These type of analyses must only be handled through the Customize... option
+   next to the AST Panel selector, above the results entry listing -->
+  <subscriber
+    for="bika.lims.browser.analysisrequest.manage_analyses.AnalysisRequestAnalysesView
+         bika.lims.interfaces.IAnalysisRequest"
+    provides="senaite.app.listing.interfaces.IListingViewAdapter"
+    factory=".analysisrequest.ManageAnalysesViewAdapter" />
+
+  <!-- Do not display AST-type analyses for selection in Worksheet's Add
+    Analyses view. Default senaite layout of worksheets does not work for the
+    introduction of AST results for multiple Samples at once. Therefore, the
+    submission of AST analyses must be done individually, sample by sample,
+    unless an AST-type worksheet with a suitable layout is added -->
+  <subscriber
+    for="bika.lims.browser.worksheet.views.AddAnalysesView
+         bika.lims.interfaces.IWorksheet"
+    provides="senaite.app.listing.interfaces.IListingViewAdapter"
+    factory=".worksheet.AddAnalysesViewAdapter" />
+
+</configure>

--- a/src/senaite/ast/adapters/listing/configure.zcml
+++ b/src/senaite/ast/adapters/listing/configure.zcml
@@ -61,4 +61,11 @@
     provides="senaite.app.listing.interfaces.IListingViewAdapter"
     factory=".worksheet.AddAnalysesViewAdapter" />
 
+  <!-- Analyses listing adapter -->
+  <subscriber
+    for="bika.lims.browser.analyses.view.AnalysesView
+         bika.lims.interfaces.IAnalysisRequest"
+    provides="senaite.app.listing.interfaces.IListingViewAdapter"
+    factory=".analyses.AnalysesViewAdapter" />
+
 </configure>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

> [!IMPORTANT] 
> Requires:
> - https://github.com/senaite/senaite.core/pull/2753

This Pull Request ensures the sample view fully reloads after submitting the "Microorganism Identification" analysis.

The introduction of the [Sequential Ajax Transitions](https://github.com/senaite/senaite.app.listing/pull/108) feature allows transitions to be processed asynchronously via AJAX without requiring a full view reload. When the "submit" transition is configured as an "Active Ajax Transition," the full view is not reloaded after submitting results. While this behavior is acceptable in most cases, it creates an issue for the "Microorganism Identification" analysis. Without a full reload, users must manually refresh the page to render the AST Panel selector, which is essential for choosing panels that align with the microorganisms reported in the analysis.

This Pull Request eliminates the need for manual page refreshes. Now, the view automatically reloads after submitting the "Microorganism Identification" analysis, ensuring the AST Panel selector is properly displayed, regardless of the "Ajax Transition" configuration.

## Current behavior before PR

User has to manually reload the view to display the AST Panels selector

## Desired behavior after PR is merged

The AST panels selector is displayed automatically after submit of "Microorganism Identification" analysis

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
