### PR TITLE
Update Github Action to use latest ubuntu

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,29 +6,72 @@ env:
   PLONE_VERSION: "5.2"
 jobs:
   build-and-test:
-    runs-on: 'ubuntu-20.04'
-    container:
-      image: python:2.7.18-buster
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: cache eggs
-        uses: actions/cache@v3
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Cache pyenv Python builds
+        uses: actions/cache@v4
+        with:
+          path: ~/.pyenv
+          key: pyenv-2.7.18-${{ runner.os }}
+          restore-keys: |
+            pyenv-2.7.18-
+
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y make build-essential libssl-dev \
+              zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev \
+              wget curl llvm libncurses5-dev xz-utils tk-dev libxml2-dev \
+              libxmlsec1-dev libffi-dev liblzma-dev
+
+      - name: Install pyenv
+        run: |
+          if [ ! -d "$HOME/.pyenv" ]; then
+            curl https://pyenv.run | bash
+          fi
+
+      - name: Install Python 2.7 with pyenv (if not cached)
+        run: |
+          export PYENV_ROOT="$HOME/.pyenv"
+          export PATH="$PYENV_ROOT/bin:$PATH"
+          eval "$(pyenv init --path)"
+          pyenv install 2.7.18 || true  # Avoid reinstalling if already cached
+          pyenv global 2.7.18
+
+      - name: Verify Python Version
+        run: |
+          export PYENV_ROOT="$HOME/.pyenv"
+          export PATH="$PYENV_ROOT/bin:$PATH"
+          eval "$(pyenv init --path)"
+          python --version  # Should output Python 2.7.18
+
+      - name: Cache eggs
+        uses: actions/cache@v4
         with:
           key: eggs-cache-${{ hashFiles('buildout.cfg', 'requirements.txt') }}
           path: |
             eggs/
-      - name: install
+
+      - name: Install dependencies and setup virtualenv
         run: |
+          export PYENV_ROOT="$HOME/.pyenv"
+          export PATH="$PYENV_ROOT/bin:$PATH"
+          eval "$(pyenv init --path)"
           pip install virtualenv
           virtualenv -p `which python` .
-          bin/pip install --upgrade pip
-          bin/pip install -r requirements.txt
-          bin/buildout -N -t 3 annotate
-          bin/buildout -N -t 3
+          ./bin/pip install --upgrade pip
+          ./bin/pip install -r requirements.txt
+          ./bin/buildout -N -t 3 annotate
+          ./bin/buildout -N -t 3
+  
       - name: lint
         run: |
-          bin/pip install flake8
-          bin/flake8 --config ci_flake8.cfg src/senaite/
+          ./bin/pip install flake8
+          ./bin/flake8 --config ci_flake8.cfg src/senaite/
+
       - name: test
         run: |
-          bin/test -s senaite.ast.tests
+          ./bin/test -s senaite.ast.tests


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR updates the GitHub action to use `ubuntu-latest` due to this accouncement:

---

The Ubuntu 20.04 runner image will be fully unsupported by April 1, 2025. To raise awareness of the upcoming removal, we will temporarily fail jobs using Ubuntu 20.04. Builds that are scheduled to run during the brownout periods will fail. The brownouts are scheduled for the following dates and times:

March 4 14:00 UTC – 22:00 UTC
March 11 13:00 UTC – 21:00 UTC
March 18 13:00 UTC – 21:00 UTC
March 25 13:00 UTC – 21:00 UTC
What you need to do

Jobs using the ubuntu-20.04 YAML workflow label should be updated to ubuntu-22.04, ubuntu-24.04 or ubuntu-latest. You can always get up-to-date information on our tools by reading about the software in the [runner images repository](https://app.github.media/e/er?s=88570519&lid=3455&elqTrackId=1befe7689f3c4a1a9cba67758d7c6fa0&elq=5a935d2f562545389886a76b81bdba2b&elqaid=4309&elqat=1&elqak=8AF512931A9D3060F4A93E1FC36635281ABF09F623AAA206E910BE71975C2C8355F1). Please contact GitHub [Support](https://app.github.media/e/er?s=88570519&lid=3338&elqTrackId=51ced43500f64a46924167a4a536829b&elq=5a935d2f562545389886a76b81bdba2b&elqaid=4309&elqat=1&elqak=8AF5D818E42E3357A6143F29D23F7AD3B3C109F623AAA206E910BE71975C2C8355F1) if you run into any problems or need help.

---


## Current behavior before PR

Ubuntu 20 is used with a Python 2.7 container

## Desired behavior after PR is merged

Ubuntu latest is used that installs Python 2.7 with PyEnv

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
