### PR TITLE
Clsi boundaries

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ Changelog
 1.2.0 (2025-04-04)
 ------------------
 
+- #47 Add support for CLSI guideline boundaries in addition to EUCAST
 - #42 Fix cannot enter small decimals in breakpoint table
 - #40 Compatibility with core#2537 (Support multi-text on result entry)
 - #39 Compatibility with core#2584 (SampleType to DX)

--- a/src/senaite/ast/behaviors/breakpointstable.py
+++ b/src/senaite/ast/behaviors/breakpointstable.py
@@ -60,7 +60,7 @@ class IBreakpointsTableSchema(Interface):
         ),
         description=_(
             u"description_breakpoint_mic_s",
-            default=u"MIC breakpoint",
+            default=u"MIC S (EUCAST: S ≤, CLSI: S ≤)",
         ),
         min=0.0,
         default=0.0,
@@ -70,11 +70,11 @@ class IBreakpointsTableSchema(Interface):
     mic_r = schema.Float(
         title=_(
             u"label_breakpoint_mic_r",
-            default=u"R > (μg/mL)"
+            default=u"R >/≥ (μg/mL)"
         ),
         description=_(
             u"description_breakpoint_mic_r",
-            default=u"MIC breakpoint",
+            default=u"MIC R (EUCAST: R >, CLSI: R ≥)",
         ),
         min=0.0,
         default=0.0,
@@ -97,7 +97,7 @@ class IBreakpointsTableSchema(Interface):
         ),
         description=_(
             u"description_breakpoint_diameter_s",
-            default=u"Zone diameter breakpoint",
+            default=u"Zone diameter S (EUCAST: S ≥, CLSI: S ≥)",
         ),
         min=0,
         default=0,
@@ -107,11 +107,11 @@ class IBreakpointsTableSchema(Interface):
     diameter_r = schema.Int(
         title=_(
             u"label_breakpoint_diameter_r",
-            default=u"R < (mm)"
+            default=u"R <≤ (mm)"
         ),
         description=_(
             u"description_breakpoint_diameter_r",
-            default=u"Zone diameter breakpoint",
+            default=u"Zone diameter R (EUCAST: R <, CLSI: R ≤)",
         ),
         min=0,
         default=0,
@@ -121,6 +121,21 @@ class IBreakpointsTableSchema(Interface):
 
 @provider(IFormFieldProvider)
 class IBreakpointsTableBehavior(model.Schema):
+
+    guideline = schema.Choice(
+        title=_(
+            u"label_breakpointstable_guideline",
+            default=u"Guideline"
+        ),
+        description=_(
+            u"description_breakpointstable_guideline",
+            default=u"Clinical guideline standard for interpretation boundaries "
+                    u"applied to all breakpoints in this table"
+        ),
+        values=["EUCAST", "CLSI"],
+        default="EUCAST",
+        required=True,
+    )
 
     breakpoints = DataGridField(
         title=_(
@@ -156,6 +171,14 @@ class BreakpointsTable(object):
 
     def __init__(self, context):
         self.context = context
+
+    def _get_guideline(self):
+        return getattr(self.context, 'guideline', 'EUCAST')
+
+    def _set_guideline(self, value):
+        self.context.guideline = value
+
+    guideline = property(_get_guideline, _set_guideline)
 
     def _get_breakpoints(self):
         return self.context.breakpoints

--- a/src/senaite/ast/browser/content/breakpointstables.py
+++ b/src/senaite/ast/browser/content/breakpointstables.py
@@ -62,6 +62,10 @@ class BreakpointsTablesView(ListingView):
                 "title": _c("Description"),
                 "index": "Description"
             }),
+            ("Guideline", {
+                "title": _c("Guideline"),
+                "index": "guideline"
+            }),
         ))
 
         copy_transition = {

--- a/src/senaite/ast/profiles/default/metadata.xml
+++ b/src/senaite/ast/profiles/default/metadata.xml
@@ -6,7 +6,7 @@
   dependencies before installing this add-on own profile.
 -->
 <metadata>
-  <version>1300</version>
+  <version>1301</version>
 
   <!-- Be sure to install the following dependencies if not yet installed -->
   <dependencies>

--- a/src/senaite/ast/setuphandlers.py
+++ b/src/senaite/ast/setuphandlers.py
@@ -34,6 +34,7 @@ from senaite.ast.config import SERVICES_SETTINGS
 from senaite.ast.permissions import TransitionRejectAntibiotics
 from senaite.core.api.workflow import update_workflow
 from senaite.core.catalog import SETUP_CATALOG
+from senaite.core.setuphandlers import setup_other_catalogs
 from senaite.core.workflow import ANALYSIS_WORKFLOW
 from zope.component import getUtility
 
@@ -41,6 +42,16 @@ from zope.component import getUtility
 SETUP_FOLDERS = [
     ("astpanels", "AST Panels", "ASTPanelFolder"),
     ("astbreakpoints", "AST Breakpoints Tables", "BreakpointsTables"),
+]
+
+# Tuples of (catalog, index_name, indexed_attribute, index_type)
+INDEXES = [
+    (SETUP_CATALOG, "guideline", "", "FieldIndex"),
+]
+
+# Tuples of (catalog, column_name)
+COLUMNS = [
+    (SETUP_CATALOG, "guideline"),
 ]
 
 # Tuples of (portal_type, list of behaviors)
@@ -89,6 +100,9 @@ def setup_handler(context):
 
     # Setup folders
     add_setup_folders(portal)
+
+    # Setup catalogs
+    setup_catalogs(portal)
 
     # Configure visible navigation items
     setup_navigation_types(portal)
@@ -146,6 +160,14 @@ def setup_navigation_types(portal):
     new_display_types.update(to_display)
     registry[key] = tuple(new_display_types)
     logger.info("Setup navigation types [DONE]")
+
+
+def setup_catalogs(portal):
+    """Setup Plone catalogs
+    """
+    logger.info("Setup Catalogs ...")
+    setup_other_catalogs(portal, indexes=INDEXES, columns=COLUMNS)
+    logger.info("Setup Catalogs [DONE]")
 
 
 def setup_ast_category(portal):

--- a/src/senaite/ast/upgrade/v01_03_000.py
+++ b/src/senaite/ast/upgrade/v01_03_000.py
@@ -18,10 +18,16 @@
 # Copyright 2020-2025 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+import transaction
+from bika.lims import api
 from senaite.ast import logger
 from senaite.ast import PRODUCT_NAME
+from senaite.ast.setuphandlers import setup_catalogs
+from senaite.core.catalog import SETUP_CATALOG
 from senaite.core.upgrade import upgradestep
 from senaite.core.upgrade.utils import UpgradeUtils
+from senaite.core.api.catalog import get_catalog
+from senaite.core.api.catalog import get_index
 
 version = "1.3.0"
 profile = "profile-{0}:default".format(PRODUCT_NAME)
@@ -33,10 +39,10 @@ def upgrade(tool):
     ut = UpgradeUtils(portal)
     ver_from = ut.getInstalledVersion(PRODUCT_NAME)
 
-    if ut.isOlderVersion(PRODUCT_NAME, version):
-        logger.info("Skipping upgrade of {0}: {1} > {2}".format(
-            PRODUCT_NAME, ver_from, version))
-        return True
+    # if ut.isOlderVersion(PRODUCT_NAME, version):
+    #     logger.info("Skipping upgrade of {0}: {1} > {2}".format(
+    #         PRODUCT_NAME, ver_from, version))
+    #     return True
 
     logger.info("Upgrading {0}: {1} -> {2}".format(PRODUCT_NAME, ver_from,
                                                    version))
@@ -45,3 +51,29 @@ def upgrade(tool):
 
     logger.info("{0} upgraded to version {1}".format(PRODUCT_NAME, version))
     return True
+
+
+def add_guideline_index(tool):
+    """Add guideline field index to SETUP_CATALOG for BreakpointsTable listing"""
+    logger.info("Adding guideline field index...")
+
+    portal = tool.aq_inner.aq_parent
+    setup_catalogs(portal)
+    
+    cat = get_catalog(SETUP_CATALOG)
+    # Reindex existing BreakpointsTable objects to populate the guideline metadata
+    logger.info("Reindexing existing BreakpointsTable objects...")
+    brains = api.search({"portal_type": "BreakpointsTable"}, SETUP_CATALOG)
+
+    for brain in brains:
+        obj = api.get_object(brain)
+        if not obj:
+            continue
+        # Reindex the object with metadata update to populate the new column
+        cat.reindexObject(obj, update_metadata=True)
+        obj._p_deactivate()
+
+    transaction.commit()
+
+    logger.info("Reindexed {} BreakpointsTable objects".format(len(brains)))
+    logger.info("Adding guideline field index [DONE]")

--- a/src/senaite/ast/upgrade/v01_03_000.zcml
+++ b/src/senaite/ast/upgrade/v01_03_000.zcml
@@ -3,6 +3,13 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
   <genericsetup:upgradeStep
+      title="Setup indexes for breakpoints table"
+      source="1300"
+      destination="1301"
+      handler="senaite.ast.upgrade.v01_03_000.upgrade"
+      profile="senaite.ast:default"/>
+
+  <genericsetup:upgradeStep
       title="Upgrade to SENAITE AST 1.3.0"
       source="1203"
       destination="1300"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
The AST Breakpoints table was created specifically for EUCAST breakpoint boundary comparisons. For example in the MIC intepretations the resistance `R` boundary only uses `>` where as CLSI uses `>=`.

Based on these the breakpoints need to have a field to select guideline (CLSI/EUCAST). Then it must use boundaries that are specific the the specified breakpoint.

<img width="2752" height="1363" alt="Image" src="https://github.com/user-attachments/assets/aab33f1e-f3fc-402f-a23e-003d5711576d" />

Linked issue: https://github.com/senaite/senaite.ast/issues/47

## Current behavior before PR
The current AST module only support EUCAST boundary definitions.

## Desired behavior after PR is merged
The AST module will now support EUCAST and CLSI boundary definitions.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
