### PR TITLE
Fix unable to submit AST results when auto-fetch transitions is disabled

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 1.3.0 (unreleased)
 ------------------
 
+- #52 Always fetch transitions on select in AST results entry view
 - #51 Support for operators, fractions and decimals in zone diameter and MIC
 - #50 Compatibility with senaite.core#2600 (Calculations to DX)
 - #49 Default all antibiotics to reportable when selective reporting is enabled

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 1.3.0 (unreleased)
 ------------------
 
-- #52 Always fetch transitions on select in AST results entry view
+- #52 Fix unable to submit AST results when auto-fetch transitions is disabled
 - #51 Support for operators, fractions and decimals in zone diameter and MIC
 - #50 Compatibility with senaite.core#2600 (Calculations to DX)
 - #49 Default all antibiotics to reportable when selective reporting is enabled

--- a/src/senaite/ast/browser/results.py
+++ b/src/senaite/ast/browser/results.py
@@ -86,6 +86,14 @@ class ManageResultsView(AnalysesView):
         self.show_workflow_action_buttons = True
         self.show_search = False
 
+        # Always fetch the available workflow transitions when analyses get
+        # selected, regardless of the `listing_fetch_transitions_on_select`
+        # global setting (senaite.app.listing#173). Results entry in this view
+        # relies on the workflow action buttons (e.g. "Submit") becoming
+        # available on selection. If auto-fetch is disabled site-wide, those
+        # buttons never show up and the user is unable to submit results
+        self.fetch_transitions_on_select = True
+
         # Add the Microorganism column
         new_columns = (
             ("Microorganism", {


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

[senaite.app.listing#173](https://github.com/senaite/senaite.app.listing/pull/173) introduced a global registry setting, `listing_fetch_transitions_on_select`, that lets a site disable the automatic fetching of workflow transitions when items are selected in a listing (to reduce the cost of the per-select `ajax_transitions` round-trip on contended instances).

The AST results entry listing (`ManageResultsView`) relies on the workflow action buttons (e.g. "Submit") becoming available when analyses are selected. When auto-fetch is disabled site-wide, those buttons never appear in this view, leaving the user unable to submit AST results.

## Current behavior before PR

With `listing_fetch_transitions_on_select` set to `False` globally, selecting analyses in the AST results entry view does not surface the workflow action buttons. The "Submit" action is therefore unreachable and results cannot be submitted from this view.


## Desired behavior after PR is merged

`ManageResultsView` pins the per-listing `fetch_transitions_on_select` attribute to `True`, which takes precedence over the global registry default (see `AjaxListingView.get_fetch_transitions_on_select`). The AST results entry view always fetches the available transitions on select, so the "Submit" button is available regardless of the site-wide setting. No front-end rebuild is required — the listing already honors the per-listing value

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
