### PR TITLE
Compatibility with core#2962 (Remove RegulatoryInspector)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 1.3.0 (unreleased)
 ------------------
 
+- #53 Compatibility with core#2962 (Remove RegulatoryInspector)
 - #52 Fix unable to submit AST results when auto-fetch transitions is disabled
 - #51 Support for operators, fractions and decimals in zone diameter and MIC
 - #50 Compatibility with senaite.core#2600 (Calculations to DX)

--- a/src/senaite/ast/profiles/default/rolemap.xml
+++ b/src/senaite/ast/profiles/default/rolemap.xml
@@ -8,7 +8,6 @@
     <role name="LabManager"/>
     <role name="Preserver"/>
     <role name="Publisher"/>
-    <role name="RegulatoryInspector"/>
     <role name="Sampler"/>
     <role name="SamplingCoordinator"/>
     <role name="Verifier"/>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

> [!IMPORTANT]
> Requires:
> - https://github.com/senaite/senaite.core/pull/2962

This Pull Request makes this product compatible with https://github.com/senaite/senaite.core/pull/2962


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
